### PR TITLE
토큰 인증 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/user/entity/User.java
+++ b/src/main/java/com/limvik/econome/domain/user/entity/User.java
@@ -38,6 +38,7 @@ public class User {
     @CreationTimestamp
     private Instant createTime;
 
+    @Setter
     @Column
     private String refreshToken;
 

--- a/src/main/java/com/limvik/econome/domain/user/service/UserService.java
+++ b/src/main/java/com/limvik/econome/domain/user/service/UserService.java
@@ -39,10 +39,20 @@ public class UserService implements UserDetailsService {
             throw new ErrorException(ErrorCode.DUPLICATED_EMAIL);
     }
 
-    @Transactional(readOnly = true)
     public Map<String, String> getTokens(User user) {
         return Map.of("accessToken", jwtProvider.generateAccessToken(user),
                       "refreshToken", jwtProvider.generateRefreshToken(user));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean matchRefreshToken(User user) {
+        return userRepository.existsByIdAndRefreshToken(user.getId(), user.getRefreshToken());
+
+    }
+
+    @Transactional
+    public User updateUser(User user) {
+        return userRepository.save(user);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/limvik/econome/global/config/JwtConfig.java
+++ b/src/main/java/com/limvik/econome/global/config/JwtConfig.java
@@ -12,7 +12,8 @@ import org.springframework.context.annotation.Configuration;
 public class JwtConfig {
 
     private String issuer;
-    private String key;
+    private String accessKey;
+    private String refreshKey;
     private Long accessTokenExpirationMinutes;
     private Long refreshTokenExpirationDays;
 

--- a/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
+++ b/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     DUPLICATED_USERNAME(HttpStatus.CONFLICT,"이미 존재하는 사용자 이름입니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     UNPROCESSABLE_USERINFO(HttpStatus.UNPROCESSABLE_ENTITY, "입력된 정보가 형식에 맞지 않습니다."),
-    NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자 정보가 없습니다.");
+    NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자 정보가 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/limvik/econome/global/security/authentication/BearerAuthenticationToken.java
+++ b/src/main/java/com/limvik/econome/global/security/authentication/BearerAuthenticationToken.java
@@ -1,0 +1,31 @@
+package com.limvik.econome.global.security.authentication;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Transient;
+
+/**
+ * Authorization 헤더에 지정된 Bearer 정보를 저장하는 클래스입니다.
+ */
+@Getter
+@Transient
+public class BearerAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final String token;
+
+    public BearerAuthenticationToken(String token) {
+        super(null);
+        this.token = token;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return token;
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/authentication/JwtAuthenticationToken.java
+++ b/src/main/java/com/limvik/econome/global/security/authentication/JwtAuthenticationToken.java
@@ -1,0 +1,52 @@
+package com.limvik.econome.global.security.authentication;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.Transient;
+
+import java.util.Collection;
+
+/**
+ * HTTP 요청의 Authorization 헤더에서 추출된 JWT 문자열을 변환된 Jws 객체 형태로 저장하는 클래스입니다.
+ */
+@Transient
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Jws<Claims> token;
+
+    private Object credentials;
+
+    private Object principal;
+
+    public JwtAuthenticationToken(Jws<Claims> token) {
+        super(null);
+        this.token = token;
+    }
+
+    public JwtAuthenticationToken(Jws<Claims> token, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.setAuthenticated(true);
+        this.token = token;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    public void setPrincipal(Object userDetails) {
+        this.principal = userDetails;
+    }
+
+    public Claims getClaims() {
+        return token.getPayload();
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/authentication/JwtAuthenticationToken.java
+++ b/src/main/java/com/limvik/econome/global/security/authentication/JwtAuthenticationToken.java
@@ -16,19 +16,17 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
     private final Jws<Claims> token;
 
+    private final String tokenString;
+
     private Object credentials;
 
     private Object principal;
 
-    public JwtAuthenticationToken(Jws<Claims> token) {
-        super(null);
-        this.token = token;
-    }
-
-    public JwtAuthenticationToken(Jws<Claims> token, Collection<? extends GrantedAuthority> authorities) {
+    public JwtAuthenticationToken(Jws<Claims> token, String tokenString, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
-        this.setAuthenticated(true);
         this.token = token;
+        this.tokenString = tokenString;
+        this.setAuthenticated(true);
     }
 
     @Override
@@ -47,6 +45,10 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
     public Claims getClaims() {
         return token.getPayload();
+    }
+
+    public String getTokenString() {
+        return tokenString;
     }
 
 }

--- a/src/main/java/com/limvik/econome/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/limvik/econome/global/security/filter/JwtFilter.java
@@ -1,0 +1,88 @@
+package com.limvik.econome.global.security.filter;
+
+import com.limvik.econome.global.security.authentication.BearerAuthenticationToken;
+import com.limvik.econome.global.security.jwt.entrypoint.JwtEntryPoint;
+import com.limvik.econome.global.security.resolver.BearerResolver;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 로그인을 통해 사용자가 받은 JWT를 인증하는 Filter 클래스입니다.
+ */
+public class JwtFilter extends OncePerRequestFilter {
+    private final AuthenticationManager authenticationManager;
+
+    private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
+            new WebAuthenticationDetailsSource();
+
+    private final BearerResolver bearerResolver = new BearerResolver();
+
+    private final AuthenticationEntryPoint authenticationEntryPoint = new JwtEntryPoint();
+
+    public JwtFilter(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    /**
+     * HTTP 요청 정보가 저장된 {@link HttpServletRequest} 객체에서 JWT를 추출하여 인증을 수행합니다.
+     * JWT가 필요없는 요청의 경우 JWT 인증 작업을 수행하지 않습니다.
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final boolean debug = this.logger.isDebugEnabled();
+
+        String token;
+
+        try {
+            token = this.bearerResolver.resolve(request);
+        } catch (AuthenticationException invalid) {
+            this.authenticationEntryPoint.commence(request, response, invalid);
+            return;
+        }
+
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        BearerAuthenticationToken authenticationRequest = new BearerAuthenticationToken(token);
+
+        authenticationRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+
+        try {
+            Authentication authenticationResult = this.authenticationManager.authenticate(authenticationRequest);
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authenticationResult);
+            SecurityContextHolder.setContext(context);
+
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException failed) {
+            SecurityContextHolder.clearContext();
+
+            if (debug) {
+                this.logger.debug("인증 실패: " + failed);
+            }
+
+            this.authenticationEntryPoint.commence(request, response, failed);
+        }
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/jwt/entrypoint/JwtEntryPoint.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/entrypoint/JwtEntryPoint.java
@@ -1,0 +1,38 @@
+package com.limvik.econome.global.security.jwt.entrypoint;
+
+import com.limvik.econome.global.security.jwt.exception.JwtAuthenticationException;
+import com.limvik.econome.global.security.jwt.exception.JwtError;
+import com.limvik.econome.global.security.jwt.handler.JwtErrorHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+/**
+ * JWT를 이용한 인증 과정에서 인증 오류 발생 시 반환할 정보를 지정하는 클래스입니다.
+ */
+public class JwtEntryPoint implements AuthenticationEntryPoint {
+
+    private final JwtErrorHandler handler = new JwtErrorHandler();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) {
+        if (authException instanceof JwtAuthenticationException e) {
+
+            JwtError error = e.getError();
+
+            this.handler.handle(
+                    request,
+                    response,
+                    error.getHttpStatus(), error.getErrorCode(),
+                    error.getDescription(), error.getUri());
+        } else {
+            this.handler.handle(request, response, HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/jwt/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/exception/JwtAuthenticationException.java
@@ -1,0 +1,19 @@
+package com.limvik.econome.global.security.jwt.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * JWT 인증 작업 중 오류 발생 시 던져지는 예외(Exception) 클래스입니다.
+ */
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final JwtError error;
+
+    public JwtAuthenticationException(JwtError error, String message) {
+        super(message);
+        this.error = error;
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/jwt/exception/JwtError.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/exception/JwtError.java
@@ -1,0 +1,35 @@
+package com.limvik.econome.global.security.jwt.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * JWT 와 관련된 에러 내용을 저장하는 클래스입니다.
+ */
+@Getter
+public class JwtError {
+
+    private HttpStatus httpStatus;
+
+    private final String errorCode;
+
+    private final String description;
+
+    private final String uri;
+
+    public JwtError(String errorCode, String description, String uri) {
+        this.errorCode = errorCode;
+        this.description = description;
+        this.uri = uri;
+    }
+
+    public JwtError(String errorCode, HttpStatus httpStatus) {
+        this(errorCode, httpStatus, null, null);
+    }
+
+    public JwtError(String errorCode, HttpStatus httpStatus, String description, String errorUri) {
+        this(errorCode, description, errorUri);
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/jwt/handler/JwtErrorHandler.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/handler/JwtErrorHandler.java
@@ -1,0 +1,74 @@
+package com.limvik.econome.global.security.jwt.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Setter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * JWT 관련 작업 중 발생한 오류에 관한 정보를 사용자에게 어떻게 보여줄지 지정하는 클래스입니다.
+ */
+@Setter
+public class JwtErrorHandler {
+
+    private String realmName;
+
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            HttpStatus httpStatus) {
+
+        this.handle(response, authParamAttributes(), httpStatus);
+    }
+
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            HttpStatus httpStatus, String error, String description, String uri) {
+
+        Map<String, String> authParamAttributes = authParamAttributes();
+
+        authParamAttributes.put("error", error);
+
+        if (description != null) {
+            authParamAttributes.put("error_description", description);
+        }
+
+        if (uri != null) {
+            authParamAttributes.put("error_uri", uri);
+        }
+
+        this.handle(response, authParamAttributes, httpStatus);
+    }
+
+    private Map<String, String> authParamAttributes() {
+        Map<String, String> authParamAttributes = new LinkedHashMap<>();
+
+        if ( this.realmName != null ) {
+            authParamAttributes.put("realm", this.realmName);
+        }
+
+        return authParamAttributes;
+    }
+
+    private void handle(
+            HttpServletResponse response,
+            Map<String, String> authParamAttributes,
+            HttpStatus httpStatus) {
+
+        String wwwAuthenticate = "Bearer";
+        if (!authParamAttributes.isEmpty()) {
+            wwwAuthenticate += authParamAttributes.entrySet().stream()
+                    .map(attribute -> attribute.getKey() + "=\"" + attribute.getValue() + "\"")
+                    .collect(Collectors.joining(", ", " ", ""));
+        }
+        response.addHeader(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
+        response.setStatus(httpStatus.value());
+    }
+
+}

--- a/src/main/java/com/limvik/econome/global/security/jwt/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/provider/JwtAuthenticationProvider.java
@@ -1,0 +1,73 @@
+package com.limvik.econome.global.security.jwt.provider;
+
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.security.authentication.BearerAuthenticationToken;
+import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
+import com.limvik.econome.global.security.jwt.exception.JwtAuthenticationException;
+import com.limvik.econome.global.security.jwt.exception.JwtError;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.security.InvalidKeyException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * JWT의 인증작업을 수행하는 클래스입니다.
+ * Spring Security의 {@link org.springframework.security.authentication.ProviderManager} 의 인수로 사용됩니다.
+ */
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationProvider(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    /**
+     * {@link BearerAuthenticationToken}을 받아 JWT로 parsing 및 인증한 후 {@link JwtAuthenticationToken}을 반환합니다.
+     * @param authentication {@link BearerAuthenticationToken}
+     * @return {@link JwtAuthenticationToken}
+     */
+    @Override
+    public Authentication authenticate(Authentication authentication)
+            throws AuthenticationException {
+        var bearerToken = (BearerAuthenticationToken) authentication;
+        Jws<Claims> jws = parseToken(bearerToken.getToken());
+        return getAuthenticatedToken(jws);
+    }
+
+    private Jws<Claims> parseToken(String token) {
+        Jws<Claims> jws;
+        try {
+            jws = jwtProvider.parse(token, jwtProvider.getAccessKey());
+        } catch (InvalidKeyException e){
+            jws = jwtProvider.parse(token, jwtProvider.getRefreshKey());
+        } catch (JwtException e) {
+            var error = new JwtError(ErrorCode.INVALID_TOKEN.name(), ErrorCode.INVALID_TOKEN.getHttpStatus());
+            throw new JwtAuthenticationException(error, ErrorCode.INVALID_TOKEN.getMessage());
+        }
+        return jws;
+    }
+
+    private Authentication getAuthenticatedToken(Jws<Claims> jws) {
+        var auth = new JwtAuthenticationToken(jws, List.of(new SimpleGrantedAuthority("USER")));
+        auth.setAuthenticated(true);
+        auth.setPrincipal(Objects.requireNonNull(jws).getPayload().getSubject());
+        return auth;
+    }
+
+    /**
+     * authenticate 메서드의 인수로 받아 인증을 수행할 Token을 지정하고, 사용가능 여부를 반환합니다.
+     * @param authentication 인증을 수행할 Token
+     */
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return BearerAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/limvik/econome/global/security/resolver/BearerResolver.java
+++ b/src/main/java/com/limvik/econome/global/security/resolver/BearerResolver.java
@@ -1,0 +1,44 @@
+package com.limvik.econome.global.security.resolver;
+
+import com.limvik.econome.global.security.jwt.exception.JwtAuthenticationException;
+import com.limvik.econome.global.security.jwt.exception.JwtError;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Authorization 헤더에서 Bearer 뒤의 JWT를 추출하는 클래스입니다.
+ */
+public class BearerResolver {
+
+    private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+)=*$");
+
+    /**
+     * {@link HttpServletRequest} 객체에 저장된 HTTP 요청 정보로부터 Authorization 헤더 정보를 받아 JWT 토큰을 추출하고 반환합니다.
+     * @param request HTTP 요청 정보가 저장된 객체
+     * @return 문자열(String) 형식의 JWT 토큰
+     */
+    public String resolve(HttpServletRequest request) {
+        return resolveFromAuthorizationHeader(request);
+    }
+
+    private String resolveFromAuthorizationHeader(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer")) {
+            Matcher matcher = authorizationPattern.matcher(authorization);
+
+            if ( !matcher.matches() ) {
+                JwtError error = new JwtError("invalid_request", HttpStatus.BAD_REQUEST);
+                throw new JwtAuthenticationException(error, "토큰 형식 오류");
+            }
+
+            return matcher.group("token");
+        }
+        return null;
+    }
+
+}
+

--- a/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
@@ -10,4 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
+    boolean existsByIdAndRefreshToken(Long id, String refreshToken);
 }

--- a/src/main/java/com/limvik/econome/web/user/dto/TokenResponse.java
+++ b/src/main/java/com/limvik/econome/web/user/dto/TokenResponse.java
@@ -1,0 +1,5 @@
+package com.limvik.econome.web.user.dto;
+
+public record TokenResponse(
+        String accessToken
+) { }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
 
 jwt:
   issuer: ${JWT_ISSUER}
-  key: ${JWT_KEY}
+  access-key: ${JWT_ACCESS_KEY}
+  refresh-key: ${JWT_REFRESH_KEY}
   access-token-expiration-minutes: 10
   refresh-token-expiration-days: 30

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -31,7 +31,8 @@ class EconomeApplicationTests {
 	@DisplayName("JWT 설정 기본값 정상 로딩")
 	void jwtConfigDataLoads() {
 		assertThat(jwtConfig.getIssuer()).isNotNull();
-		assertThat(jwtConfig.getKey()).isNotNull();
+		assertThat(jwtConfig.getAccessKey()).isNotNull();
+		assertThat(jwtConfig.getRefreshKey()).isNotNull();
 		assertThat(jwtConfig.getAccessTokenExpirationMinutes()).isNotNull();
 		assertThat(jwtConfig.getRefreshTokenExpirationDays()).isNotNull();
 	}

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -3,11 +3,11 @@ package com.limvik.econome;
 import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.global.config.JwtConfig;
 import com.limvik.econome.global.security.jwt.provider.JwtProvider;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +22,9 @@ class EconomeApplicationTests {
 
 	@Autowired
 	JwtProvider jwtProvider;
+
+	@Autowired
+	TestRestTemplate restTemplate;
 
 	@Test
 	void contextLoads() {
@@ -47,8 +50,43 @@ class EconomeApplicationTests {
 		assertThat(accessToken).isNotNull();
 		assertThat(refreshToken).isNotNull();
 
-		assertThat(jwtProvider.parse(accessToken).getPayload().getSubject()).isEqualTo("1");
-		assertThat(jwtProvider.parse(refreshToken).getPayload().getSubject()).isEqualTo("1");
+		assertThat(jwtProvider.parse(accessToken, jwtProvider.getAccessKey()).getPayload().getSubject()).isEqualTo("1");
+		assertThat(jwtProvider.parse(refreshToken, jwtProvider.getRefreshKey()).getPayload().getSubject()).isEqualTo("1");
+	}
+
+	@Test
+	@DisplayName("유효한 access token으로 엔드포인트 요청")
+	void shouldReturn200OkIfValidToken() {
+		var user = User.builder().id(1L).build();
+		String accessToken = jwtProvider.generateAccessToken(user);
+
+		var headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		HttpEntity<String> request = new HttpEntity<>(null, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+				"/api/v1/test", HttpMethod.POST, request, String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 access token으로 엔드포인트 요청")
+	void shouldReturn401UnauthorizedIfNotValidToken() {
+		String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." +
+				"eyJpc3MiOiJsaW12aWtfZWNvbm9tZSIsImlhdCI6MTY5OTY3NDk5NSwiZXhwIjoxNjk5Njc1NTk1LCJzdWIiOiI4In0." +
+				"6uvQXPz8WwXcXoNYBylmS1QWvyfdnjRSbNOg_54aP5g3jWJu7OfVugfuGb14UVJU1umMMj5Nn2KMQn4ASTiYsg";
+
+		var headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		HttpEntity<String> request = new HttpEntity<>(null, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+				"/api/v1/test", HttpMethod.POST, request, String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
 }

--- a/src/test/java/com/limvik/econome/web/mock/controller/TestController.java
+++ b/src/test/java/com/limvik/econome/web/mock/controller/TestController.java
@@ -1,0 +1,19 @@
+package com.limvik.econome.web.mock.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test")
+@ActiveProfiles("integration")
+public class TestController {
+
+    @PostMapping
+    public String test(Authentication authentication){
+        return authentication.getPrincipal().toString();
+    }
+
+}

--- a/src/test/java/com/limvik/econome/web/user/controller/UserSigninControllerTest.java
+++ b/src/test/java/com/limvik/econome/web/user/controller/UserSigninControllerTest.java
@@ -5,6 +5,7 @@ import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.domain.user.service.UserService;
 import com.limvik.econome.global.config.WebAuthorizationConfig;
 import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
 import com.limvik.econome.infrastructure.user.UserRepository;
 import com.limvik.econome.web.user.dto.SigninRequest;
 import com.limvik.econome.web.user.dto.SigninResponse;
@@ -18,7 +19,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.shaded.org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +41,9 @@ public class UserSigninControllerTest {
 
     @MockBean
     PasswordEncoder passwordEncoder;
+
+    @MockBean
+    JwtProvider jwtProvider;
 
     @MockBean
     UserRepository userRepository;

--- a/src/test/java/com/limvik/econome/web/user/controller/UserSignupControllerTest.java
+++ b/src/test/java/com/limvik/econome/web/user/controller/UserSignupControllerTest.java
@@ -6,6 +6,7 @@ import com.limvik.econome.domain.user.service.UserService;
 import com.limvik.econome.global.config.WebAuthorizationConfig;
 import com.limvik.econome.global.exception.ErrorCode;
 import com.limvik.econome.global.exception.ErrorException;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
 import com.limvik.econome.infrastructure.user.UserRepository;
 import com.limvik.econome.web.user.dto.SignupRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,9 @@ public class UserSignupControllerTest {
 
     @MockBean
     PasswordEncoder passwordEncoder;
+
+    @MockBean
+    JwtProvider jwtProvider;
 
     @MockBean
     UserRepository userRepository;


### PR DESCRIPTION
## 작업 내용

- 유효한 access token을 Authorization Header에 포함하여 전송할 경우 인증이 필요한 경로에 접근할 수 있습니다.
- `/api/v1/users/token` 경로로 유효한 refresh token을 Authorization Header에 포함하여 전송할 경우 access token을 반환합니다.

## 작업 설명

- [`ff234fb`](https://github.com/limvik/budget-management-service/commit/ff234fb9f226957a55f44f2aa31b03db5ecd9bd0)
  - access token과 refresh token에 동일한 키를 사용하였으나, access token 과 refresh token을 구분하기 위해 별도의 키로 분리하였습니다.
- [`fb0040a`](https://github.com/limvik/budget-management-service/commit/fb0040af5a0c998e3ab106e527b5d040792d0406), [`b7a0f02`](https://github.com/limvik/budget-management-service/commit/b7a0f027eec99c13acde5e7b7c0f3eb28618049d), [`ddfbb6e`](https://github.com/limvik/budget-management-service/commit/ddfbb6e5199a6eaf8210ec567f3bc0fc0a8458f0), [`b5487b3`](https://github.com/limvik/budget-management-service/commit/b5487b396ab13751f119d9d245280ed18224d6e2)
  - Authorization Header에 access token 또는 refresh token 이 포함되어 있을 경우, Filter에서 인증합니다.
  - 이전에 로그인 시 refresh token을 저장하지 않아, 저장하는 로직을 추가하였습니다.
- [`591bbf0`](https://github.com/limvik/budget-management-service/commit/591bbf0edfbc0f28c936cc9dc82e4d4b5afd317c)
  - WebAuthorizationConfig 에 JwtProvider가 추가되어 영향을 받는 테스트에 JwtProvider 의 Mock 객체를 추가하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/aa1d7c4a-1b1a-4057-a319-bac623ab05c4)

### 수동 테스트

#### 유효한 Refresh Token으로 Access Token 재발급

![image](https://github.com/limvik/budget-management-service/assets/37972432/fbd0a3f1-e378-45d1-9552-a8ccb072f27c)

#### 유효한 Aceess Token으로 인증이 필요한 엔드포인트 요청

테스트용 엔드포인트만 있어서 수동으로 테스트할 수 없습니다.

## 기타

### 시간 초과

- 예상 시간: 2H / 실제 시간: 5H
- 초과 원인
  1. 가장 큰 원인은 역시나 테스트 코드 작성. 슬라이스 테스트로 작성하려다가 mocking 해야될 객체들이 너무 많아져서 혼란스러워서 시간 보내다가 결국 TestRestTemplate 으로 테스트 작성했습니다. 테스트 코드에 대해 학습이 더 필요하겠습니다.
  2. Refresh Token을 보내서 Access Token의 key로 검증하면 `SignatureException` 인데, `InvalidKeyException` 으로 해놓아서 디버깅 하는데 시간이 걸렸습니다.
  3. 예상 시간을 계획할 때, Refresh Token을 재발급하는 것은 사실 추가할 계획이 없었는데, 없는 것도 이상한 것 같아 추가하느라 시간이 초과됐습니다. 예상했던 작업은 완료했을 때 약 10분정도의 지연이 있었습니다.

### 이전 코드 활용

- JWT 관련 코드는 많은 부분 이전 코드를 활용하여 재작성 하였습니다. 코드 스타일이 username, password 를 이용한 로그인과는 많이 달라 추후 시간 여유가 있을 때 리팩토링이 필요합니다.