### PR TITLE
카테고리별 예산 설정 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
@@ -1,0 +1,38 @@
+package com.limvik.econome.domain.budgetplan.entity;
+
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "budget_plans")
+public class BudgetPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private long amount;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
@@ -1,0 +1,31 @@
+package com.limvik.econome.domain.budgetplan.service;
+
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.exception.ErrorException;
+import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class BudgetPlanService {
+
+    private final BudgetPlanRepository budgetPlanRepository;
+
+    @Transactional
+    public List<BudgetPlan> createBudgetPlans(List<BudgetPlan> budgetPlans) {
+        if (isNotExistPlan(budgetPlans.get(0))) {
+            return budgetPlanRepository.saveAll(budgetPlans);
+        } else {
+            throw new ErrorException(ErrorCode.DUPLICATED_BUDGET_PLAN);
+        }
+    }
+
+    private boolean isNotExistPlan(BudgetPlan budgetPlan) {
+        return !budgetPlanRepository.existsByDateAndCategory(budgetPlan.getDate(), budgetPlan.getCategory());
+    }
+}

--- a/src/main/java/com/limvik/econome/domain/category/entity/Category.java
+++ b/src/main/java/com/limvik/econome/domain/category/entity/Category.java
@@ -1,11 +1,14 @@
 package com.limvik.econome.domain.category.entity;
 
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
 import com.limvik.econome.domain.category.enums.BudgetCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Builder
 @Getter
@@ -23,4 +26,6 @@ public class Category {
     @Enumerated(EnumType.STRING)
     private BudgetCategory name;
 
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<BudgetPlan> budgetPlans;
 }

--- a/src/main/java/com/limvik/econome/domain/user/entity/User.java
+++ b/src/main/java/com/limvik/econome/domain/user/entity/User.java
@@ -1,11 +1,12 @@
 package com.limvik.econome.domain.user.entity;
 
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.Instant;
+import java.util.List;
 
 @Builder
 @Getter
@@ -41,5 +42,8 @@ public class User {
     @Setter
     @Column
     private String refreshToken;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<BudgetPlan> budgetPlans;
 
 }

--- a/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
+++ b/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     UNPROCESSABLE_USERINFO(HttpStatus.UNPROCESSABLE_ENTITY, "입력된 정보가 형식에 맞지 않습니다."),
     NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자 정보가 없습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    DUPLICATED_BUDGET_PLAN(HttpStatus.CONFLICT, "이미 예산이 설정되었습니다. 원하신다면 수정을 요청해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -1,0 +1,13 @@
+package com.limvik.econome.infrastructure.budgetplan;
+
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
+
+    boolean existsByDateAndCategory(LocalDate date, Category category);
+
+}

--- a/src/main/java/com/limvik/econome/web/budgetplan/controller/BudgetPlanController.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/controller/BudgetPlanController.java
@@ -1,0 +1,57 @@
+package com.limvik.econome.web.budgetplan.controller;
+
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.budgetplan.service.BudgetPlanService;
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
+import com.limvik.econome.web.budgetplan.dto.BudgetPlanListRequest;
+import com.limvik.econome.web.util.UserUtil;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/budget-plans")
+public class BudgetPlanController {
+
+    private final BudgetPlanService budgetPlanService;
+
+    @PostMapping
+    public ResponseEntity<String> createBudgetPlan(@Valid @RequestParam @Min(1) @Max(9999) int year,
+                                                 @Valid @RequestParam @Min(1) @Max(12) int month,
+                                                 @Valid @RequestBody BudgetPlanListRequest budgetPlans,
+                                                 Authentication authentication) {
+        var token = (JwtAuthenticationToken) authentication;
+        var date = LocalDate.of(year, month, 1);
+        long userId = UserUtil.getUserIdFromJwt(token);
+        List<BudgetPlan> budgetPlanList = mapRequestToBudgetPlanList(budgetPlans, userId, date);
+
+        budgetPlanList = budgetPlanService.createBudgetPlans(budgetPlanList);
+
+        year = budgetPlanList.get(0).getDate().getYear();
+        month = budgetPlanList.get(0).getDate().getMonthValue();
+        String location = "/api/v1/budget-plans?year=%d&month=%d".formatted(year, month);
+        return ResponseEntity.created(URI.create(location)).build();
+    }
+
+    private List<BudgetPlan> mapRequestToBudgetPlanList(BudgetPlanListRequest budgetPlans, long userId, LocalDate date) {
+        return budgetPlans.budgetPlans().stream()
+                .map(budgetPlanRequest -> BudgetPlan.builder()
+                        .date(date)
+                        .user(User.builder().id(userId).build())
+                        .category(Category.builder().id(budgetPlanRequest.categoryId()).build())
+                        .amount(budgetPlanRequest.amount())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanListRequest.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanListRequest.java
@@ -1,0 +1,8 @@
+package com.limvik.econome.web.budgetplan.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record BudgetPlanListRequest(
+        List<BudgetPlanRequest> budgetPlans
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanRequest.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanRequest.java
@@ -1,0 +1,13 @@
+package com.limvik.econome.web.budgetplan.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.io.Serializable;
+
+public record BudgetPlanRequest(
+        @Min(1)
+        @Max(12)
+        long categoryId,
+        long amount
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/user/controller/UserController.java
+++ b/src/main/java/com/limvik/econome/web/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
 import com.limvik.econome.web.user.dto.SigninResponse;
 import com.limvik.econome.web.user.dto.SignupRequest;
 import com.limvik.econome.web.user.dto.TokenResponse;
+import com.limvik.econome.web.util.UserUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -67,7 +68,7 @@ public class UserController {
     @PostMapping("/token")
     public ResponseEntity<TokenResponse> token(Authentication authentication) {
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
-        long userId = getUserId(token);
+        long userId = UserUtil.getUserIdFromJwt(token);
         log.info("refresh token userId: {}", userId);
         User user = User.builder().id(userId).refreshToken(token.getTokenString()).build();
         if (userService.matchRefreshToken(user)) {
@@ -75,15 +76,6 @@ public class UserController {
             return ResponseEntity.ok(new TokenResponse(tokens.get("accessToken")));
         } else {
             log.info("유효한 토큰이지만 데이터베이스 refersh token과 다름");
-            throw new ErrorException(ErrorCode.INVALID_TOKEN);
-        }
-    }
-
-    private long getUserId(JwtAuthenticationToken token) {
-        try {
-            return Long.parseLong(token.getClaims().getSubject());
-        } catch (Exception e) {
-            log.info("Authentication 객체에 저장된 사용자 정보가 없습니다.");
             throw new ErrorException(ErrorCode.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/limvik/econome/web/util/UserUtil.java
+++ b/src/main/java/com/limvik/econome/web/util/UserUtil.java
@@ -1,0 +1,20 @@
+package com.limvik.econome.web.util;
+
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.exception.ErrorException;
+import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UserUtil {
+
+    public static long getUserIdFromJwt(JwtAuthenticationToken token) {
+        try {
+            return Long.parseLong(token.getClaims().getSubject());
+        } catch (Exception e) {
+            log.info("Authentication 객체에 저장된 사용자 정보가 없습니다.");
+            throw new ErrorException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

카테고리별로 예산을 설정할 수 있도록 테스트 및 로직을 추가하였습니다.

|상황|Response Code|Response|
|---|---|---|
|정상적인 예산 설정|201(Created)|Location header에 경로 표시|
|중복된 예산 설정|409(Conflict)|errorCode, errorReason|

## 작업 설명

- [`a67b62a`](https://github.com/limvik/budget-management-service/commit/a67b62abfd8973ba78bf7d0b145040897b2d35f6)
  - 카테고리별 예산 설정에 대한 통합 테스트를 작성하였습니다.
- [`67aaff5`](https://github.com/limvik/budget-management-service/commit/67aaff5e04a456689c681b173cd8ed591d36fb03)
  - 도메인 객체 BudgetPlan을 추가하고, 외래키인 user_id, category_id 를 나타내기 위한 관계를 설정하였습니다.
- [`8444ca8`](https://github.com/limvik/budget-management-service/commit/8444ca815881c3756bf7e6e0bc284cf93c13dce6)
  - Spring Security로 인증이 완료된 Authentication 인스턴스에 포함된 JWT에서 user id를 추출하는 코드를 유틸리티 객체로 옮겼습니다. 이후 인증받은 사용자의 id가 필요한 엔드포인트에서 공통적으로 사용할 수 있습니다.
- [`ebf7285`](https://github.com/limvik/budget-management-service/commit/ebf7285f22df35cf537acb588df1ebeabaad1393)
  - 사용자가 지정한 년도와 월에 카테고리별로 예산을 설정할 수 있는 기능을 추가하였습니다. 이미 예산이 설정되어 있는 경우, 409(Conflict)를 반환합니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/f1ce76d8-46b3-4a0d-a0d0-e6243813e0ea)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/f67ebf7b-49a6-4c9e-a18e-8fa0c4dd99b3)

## 기타

### 예상 작업 시간 초과

- 예상 시간: 2H, 실제 시간: 2.5H
- 초과 원인
  1. 역시나 테스트가 문제였습니다. Mocking 해야할 객체들이 너무 많아졌는데, 아직 Mockito 사용법이 미숙해서 인증받은 사용자 정보 객체를 어떻게 Mocking을 할지 찾아보다가 더 이상 시간 지연시킬 수 없다고 판단하여, TestRestTemplate 을 이용한 테스트로 전환하였습니다.