### PR TITLE
예산 조회 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
@@ -28,7 +28,8 @@ public class BudgetPlanService {
     }
 
     private boolean isNotExistPlan(BudgetPlan budgetPlan) {
-        return !budgetPlanRepository.existsByDateAndCategory(budgetPlan.getDate(), budgetPlan.getCategory());
+        return !budgetPlanRepository.existsByUserAndDateAndCategory(
+                budgetPlan.getUser(), budgetPlan.getDate(), budgetPlan.getCategory());
     }
 
     @Transactional

--- a/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
@@ -1,6 +1,7 @@
 package com.limvik.econome.domain.budgetplan.service;
 
 import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.global.exception.ErrorCode;
 import com.limvik.econome.global.exception.ErrorException;
 import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -27,5 +29,11 @@ public class BudgetPlanService {
 
     private boolean isNotExistPlan(BudgetPlan budgetPlan) {
         return !budgetPlanRepository.existsByDateAndCategory(budgetPlan.getDate(), budgetPlan.getCategory());
+    }
+
+    @Transactional
+    public List<BudgetPlan> getBudgetPlans(long userId, LocalDate date) {
+        var user = User.builder().id(userId).build();
+        return budgetPlanRepository.findAllByUserAndDate(user, date);
     }
 }

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -2,12 +2,16 @@ package com.limvik.econome.infrastructure.budgetplan;
 
 import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
 import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
 
     boolean existsByDateAndCategory(LocalDate date, Category category);
+
+    List<BudgetPlan> findAllByUserAndDate(User user, LocalDate date);
 
 }

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
 
-    boolean existsByDateAndCategory(LocalDate date, Category category);
+    boolean existsByUserAndDateAndCategory(User user, LocalDate date, Category category);
 
     List<BudgetPlan> findAllByUserAndDate(User user, LocalDate date);
 

--- a/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanListResponse.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanListResponse.java
@@ -1,0 +1,8 @@
+package com.limvik.econome.web.budgetplan.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record BudgetPlanListResponse(
+        List<BudgetPlanResponse> budgetPlans
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanResponse.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/dto/BudgetPlanResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.budgetplan.dto;
+
+import java.io.Serializable;
+
+public record BudgetPlanResponse(
+        long categoryId,
+        String categoryName,
+        long amount
+) implements Serializable { }

--- a/src/test/java/com/limvik/econome/infrastructure/user/UserSignupRepositoryTest.java
+++ b/src/test/java/com/limvik/econome/infrastructure/user/UserSignupRepositoryTest.java
@@ -25,8 +25,8 @@ public class UserSignupRepositoryTest {
     @DisplayName("중복되지 않은 username과 email 테스트")
     public void shouldReturnFalseIfUsernameOrEmailNotExists() {
 
-        boolean isDuplicatedEmail = userRepository.existsByEmail("test@test.com");
-        boolean isDuplicatedUsername = userRepository.existsByUsername("test");
+        boolean isDuplicatedEmail = userRepository.existsByEmail("test999@test.com");
+        boolean isDuplicatedUsername = userRepository.existsByUsername("test999");
 
         assertThat(isDuplicatedEmail).isFalse();
         assertThat(isDuplicatedUsername).isFalse();
@@ -37,8 +37,8 @@ public class UserSignupRepositoryTest {
     @DisplayName("중복된 username과 email 테스트")
     public void shouldReturnTrueIfUsernameOrEmailNotExists() {
 
-        String username = "test";
-        String email = "test@test.com";
+        String username = "test999";
+        String email = "test999@test.com";
         String encodedPassword = "$2a$12$dNSsw8M8NoAghJ6KJKzQM.fc8p9ysnufwYGhqjbasIWfjqt6axLMW";
         long minimumDailyExpense = 10000;
         boolean agreeAlarm = true;
@@ -51,8 +51,8 @@ public class UserSignupRepositoryTest {
 
         userRepository.save(user);
 
-        boolean isDuplicatedEmail = userRepository.existsByEmail("test@test.com");
-        boolean isDuplicatedUsername = userRepository.existsByUsername("test");
+        boolean isDuplicatedEmail = userRepository.existsByEmail("test999@test.com");
+        boolean isDuplicatedUsername = userRepository.existsByUsername("test999");
 
         assertThat(isDuplicatedEmail).isTrue();
         assertThat(isDuplicatedUsername).isTrue();


### PR DESCRIPTION
## 작업 내용

- 사용자가 기존에 설정해둔 예산을 연도(year)와 월(month)을 설정하여 조회할 수 있는 엔드포인트에 대한 테스트 및 기능 추가하였습니다.
  - GET /api/v1/budget-plans?year={year}&month={month}
- 기타 작업 내용
  - 중복된 테스트 데이터 제거
  - 예산 설정 기능 버그 수정

## 작업 설명

- [`32dba22`](https://github.com/limvik/budget-management-service/commit/32dba22f65e275a125b8a845fde271882f86d0e9), [`017d8b5`](https://github.com/limvik/budget-management-service/commit/017d8b54c446a4e6bfbb38060c16420bbb6497ea)
  - 사용자가 유효한 토큰을 Authorization 헤더에 추가하고, query parameter에 year 와 month를 설정하여 조회를 요청하면, 각 카테고리별 예산 설정 금액을 반환합니다.
- [`600be10`](https://github.com/limvik/budget-management-service/commit/600be1037f817e158027361c5008b5d5aad29ef1)
  - 동일한 테스트 데이터가 각 테스트마다 선언되고 있어 @BeforeAll로 선언된 메서드에서 초기화하도록 변경하였습니다.
- [`eca2470`](https://github.com/limvik/budget-management-service/commit/eca2470fb3a8d4d96d81f094f6026fced628f777)
  - 기존에 중복된 예산 설정을 방지하기 위해 데이터 존재여부를 확인하였습니다. 해당 코드에서 사용자 일치여부는 확인하지 않아, 다른 사용자의 데이터가 있어도 존재하는 것으로 판단하였습니다. 그래서 사용자 일치 여부도 확인하도록 수정하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/856a71b7-fded-4b8a-aff3-cca378809aff)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/bb1bfc1e-4e59-4b81-8ec6-85efa615d7ec)

## 기타

- 예상 시간: 1H / 작업 시간: 1H
  - 테스트를 간단하게만 했더니 시간이 남아, 버그 수정까지 했습니다. 테스트 코드를 자신있게 작성할 수 있으면 테스트에 의한 시간 예측 오류를 줄일 수 있지 않을까 생각됩니다. 일단은 제출일까지 기능을 완성하는 것에 집중하겠습니다.
  - PR 작성 시간까지 포함하면, 1H가 넘는데, 예상 시간을 작성할 때 어떤 행동까지 예상 시간의 범주에 포함시킬 것인가에 대한 고민이 필요해보입니다.