### PR TITLE
예산 수정 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
@@ -27,6 +27,21 @@ public class BudgetPlanService {
         }
     }
 
+    @Transactional
+    public void updateBudgetPlans(List<BudgetPlan> budgetPlans) {
+        budgetPlans.forEach(budgetPlan ->{
+            if (isNotExistPlan(budgetPlan))  {
+                throw new ErrorException(ErrorCode.NOT_EXIST_BUDGET_PLAN);
+            } else {
+                budgetPlanRepository.updateAmountByUserAndDateAndCategory(
+                        budgetPlan.getUser().getId(),
+                        budgetPlan.getCategory().getId(),
+                        budgetPlan.getDate(),
+                        budgetPlan.getAmount());
+            }
+        });
+    }
+
     private boolean isNotExistPlan(BudgetPlan budgetPlan) {
         return !budgetPlanRepository.existsByUserAndDateAndCategory(
                 budgetPlan.getUser(), budgetPlan.getDate(), budgetPlan.getCategory());

--- a/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
+++ b/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     UNPROCESSABLE_USERINFO(HttpStatus.UNPROCESSABLE_ENTITY, "입력된 정보가 형식에 맞지 않습니다."),
     NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자 정보가 없습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
-    DUPLICATED_BUDGET_PLAN(HttpStatus.CONFLICT, "이미 예산이 설정되었습니다. 원하신다면 수정을 요청해주세요.");
+    DUPLICATED_BUDGET_PLAN(HttpStatus.CONFLICT, "이미 예산이 설정되었습니다. 원하신다면 수정을 요청해주세요."),
+    NOT_EXIST_BUDGET_PLAN(HttpStatus.NOT_FOUND, "존재하지 않는 예산 계획입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -4,6 +4,8 @@ import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
 import com.limvik.econome.domain.category.entity.Category;
 import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,5 +15,12 @@ public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
     boolean existsByUserAndDateAndCategory(User user, LocalDate date, Category category);
 
     List<BudgetPlan> findAllByUserAndDate(User user, LocalDate date);
+
+    @Modifying
+    @Query("UPDATE BudgetPlan bp SET bp.amount = ?4 " +
+            "WHERE bp.user.id = ?1 " +
+            "AND bp.category.id = ?2 " +
+            "AND bp.date = ?3")
+    void updateAmountByUserAndDateAndCategory(long userId, long categoryId, LocalDate date, long amount);
 
 }

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -229,4 +229,33 @@ class EconomeApplicationTests {
 		}
 	}
 
+	@Test
+	@DisplayName("인증된 사용자의 예산 데이터 수정")
+	void shouldUpdateBudgetPlanIfValidUser() {
+		var headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		var newBudget = 20000L;
+		var requests = new ArrayList<BudgetPlanRequest>();
+		for (int i = 0; i < BudgetCategory.values().length; i++) {
+			requests.add(new BudgetPlanRequest(i + 1, newBudget));
+		}
+		var requestList = new BudgetPlanListRequest(requests);
+
+		String url = "/api/v1/budget-plans?year=%d&month=%d".formatted(budgetYear, budgetMonth);
+		HttpEntity<BudgetPlanListRequest> request = new HttpEntity<>(requestList, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+				url, HttpMethod.PATCH, request, String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		var budgetList = budgetPlanRepository.findAllByUserAndDate(user, LocalDate.of(budgetYear, budgetMonth, 1));
+		budgetList.forEach(budgetPlan -> {
+			assertThat(budgetList.size()).isEqualTo(BudgetCategory.values().length);
+			assertThat(budgetPlan.getAmount()).isEqualTo(newBudget);
+		});
+
+	}
+
 }


### PR DESCRIPTION
## 작업 내용

사용자가 기존에 설정해둔 예산을 새로운 예산 값으로 수정할 수 있는 엔드포인트에 대한 테스트 및 기능을 추가하였습니다.
- PATCH /api/v1/budget-plans?year={year}&month={month}

## 작업 설명

- [`ced3bb5`](https://github.com/limvik/budget-management-service/commit/ced3bb5e513b8845d144a46985156c2fe10954be), [`4b39148`](https://github.com/limvik/budget-management-service/commit/4b39148440d53fe42e985d137707d27711e04322)
  - year, month, 새로운 예산(amount) 을 받아 수정합니다.
  - 정상적인 경우 200(Ok)를 반환하고, 일치하는 예산 정보가 없는 경우 404(Not Found)를 반환합니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/e69074e8-9ab7-48c8-81c8-34d4eed4ad36)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/eee12493-595a-4b28-9297-cb6888963b88)

## 기타
- 예상 시간: 1H / 실제 시간: 0.7H
  - PR 작성까지 포함하면 거의 1H
  - JPQL 작성이 아직 미숙하여 더 빨리 끝내지는 못했습니다.
- TestRestTemplate 별도 설정 없이 PATCH 메서드 사용 가능
  - 이전에는 TestRestTemplate 사용 시 HttpClient 라이브러리를 추가하고도 추가적인 설정이 필요했는데, 이번에 혹시나해서 설정 없이 시도해봤는데, 이상 없이 PATCH 메서드가 동작합니다.