### PR TITLE
예산 추천 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
@@ -1,6 +1,7 @@
 package com.limvik.econome.domain.budgetplan.entity;
 
 import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.category.enums.BudgetCategory;
 import com.limvik.econome.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,5 +35,20 @@ public class BudgetPlan {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    /**
+     * 예산 추천 시에 사용되는 생성자입니다.
+     * @param categoryId 카테고리 식별자
+     * @param budgetCategory 카테고리
+     * @param averageAmount 전체 평균
+     */
+    public BudgetPlan(long categoryId, BudgetCategory budgetCategory, double averageAmount) {
+        this.category = Category.builder().id(categoryId).name(budgetCategory).build();
+        this.amount = ((long) averageAmount) / 10 * 10; // 1원 단위 절삭
+    }
+
+    public void addAmount(long amount) {
+        this.amount += amount;
+    }
 
 }

--- a/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/service/BudgetPlanService.java
@@ -12,12 +12,22 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 사용자의 카테고리별 예산 계획에 대한 서비스를 제공하는 클래스입니다.
+ * 저장소에서 데이터를 불러와 도메인 객체를 호출하거나 도메인 객체에서 처리할 수 없는 비즈니스 로직을 처리합니다.
+ * 그리고 처리된 데이터를 컨트롤러로 전달합니다.
+ */
 @RequiredArgsConstructor
 @Service
 public class BudgetPlanService {
 
     private final BudgetPlanRepository budgetPlanRepository;
 
+    /**
+     * 사용자가 지정한 카테고리별 예산 설정을 반영하여 저장소에 저장합니다.
+     * @param budgetPlans 사용자가 예산 설정을 요청한 데이터
+     * @return 저장된 데이터를 반환합니다.
+     */
     @Transactional
     public List<BudgetPlan> createBudgetPlans(List<BudgetPlan> budgetPlans) {
         if (isNotExistPlan(budgetPlans.get(0))) {
@@ -27,6 +37,10 @@ public class BudgetPlanService {
         }
     }
 
+    /**
+     * 기존에 사용자가 설정해둔 예산의 금액을 사용자 요청에 의해 수정합니다.
+     * @param budgetPlans 금액이 수정된 기존 카테고리별 예산
+     */
     @Transactional
     public void updateBudgetPlans(List<BudgetPlan> budgetPlans) {
         budgetPlans.forEach(budgetPlan ->{
@@ -47,9 +61,29 @@ public class BudgetPlanService {
                 budgetPlan.getUser(), budgetPlan.getDate(), budgetPlan.getCategory());
     }
 
-    @Transactional
+    /**
+     * 사용자가 원하는 일자의 사용자 카테고리별 예산 목록을 반환합니다.
+     * @param userId 사용자 식별자
+     * @param date 사용자가 조회를 원하는 일자
+     * @return 카테고리별 예산 목록 반환
+     */
+    @Transactional(readOnly = true)
     public List<BudgetPlan> getBudgetPlans(long userId, LocalDate date) {
         var user = User.builder().id(userId).build();
         return budgetPlanRepository.findAllByUserAndDate(user, date);
     }
+
+    /**
+     * 사용자의 전체 예산을 받아 카테고리별 추천 금액 목록을 반환합니다.
+     * @param amount 사용자의 총 예산
+     * @return 시스템이 추천하는 카테고리별 추천 금액 목록
+     */
+    @Transactional(readOnly = true)
+    public List<BudgetPlan> getBudgetRecommendations(long amount) {
+        List<BudgetPlan> budgetPlans = budgetPlanRepository.findRecommendedBudgetPlans(amount);
+        long totalAmount = budgetPlans.stream().mapToLong(BudgetPlan::getAmount).sum();
+        budgetPlans.get(budgetPlans.size()-1).addAmount(amount - totalAmount);
+        return budgetPlans;
+    }
+
 }

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -23,4 +23,15 @@ public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
             "AND bp.date = ?3")
     void updateAmountByUserAndDateAndCategory(long userId, long categoryId, LocalDate date, long amount);
 
+    /**
+     * 전체 서비스 이용자의 카테고리별 평균 비율에 기반한 카테고리별 추천 금액 목록을 반환합니다.
+     * @param amount 사용자의 총 예산
+     * @return 카테고리별 추천 금액 목록
+     */
+    @Query("SELECT new com.limvik.econome.domain.budgetplan.entity.BudgetPlan(bp.category.id, bp.category.name, " +
+            "(avg(bp.amount) / (SELECT sum(bp2.amount) FROM BudgetPlan bp2) * :amount) as amount) " +
+            "FROM BudgetPlan bp " +
+            "GROUP BY bp.category.id, bp.category.name")
+    List<BudgetPlan> findRecommendedBudgetPlans(long amount);
+
 }

--- a/src/main/java/com/limvik/econome/web/budgetplan/controller/BudgetPlanController.java
+++ b/src/main/java/com/limvik/econome/web/budgetplan/controller/BudgetPlanController.java
@@ -56,18 +56,6 @@ public class BudgetPlanController {
         return ResponseEntity.ok(mapBudgetPlanListToResponseList(budgetPlanList));
     }
 
-    private BudgetPlanListResponse mapBudgetPlanListToResponseList(List<BudgetPlan> budgetPlanList) {
-        List<BudgetPlanResponse> budgetPlanResponseList = new ArrayList<>();
-        for (BudgetPlan budgetPlan : budgetPlanList) {
-            BudgetPlanResponse budgetPlanResponse = new BudgetPlanResponse(
-                    budgetPlan.getCategory().getId(),
-                    budgetPlan.getCategory().getName().getCategory(),
-                    budgetPlan.getAmount());
-            budgetPlanResponseList.add(budgetPlanResponse);
-        }
-        return new BudgetPlanListResponse(budgetPlanResponseList);
-    }
-
     @PatchMapping
     public ResponseEntity<BudgetPlanListResponse> updateBudgetPlans(@Valid @RequestParam @Min(1) @Max(9999) int year,
                                                                     @Valid @RequestParam @Min(1) @Max(12) int month,
@@ -94,4 +82,23 @@ public class BudgetPlanController {
                         .build())
                 .toList();
     }
+
+    @GetMapping("/recommendations")
+    public ResponseEntity<BudgetPlanListResponse> getRecommendations(@Valid @RequestParam @Min(1) long amount) {
+        List<BudgetPlan> budgetPlanList = budgetPlanService.getBudgetRecommendations(amount);
+        return ResponseEntity.ok(mapBudgetPlanListToResponseList(budgetPlanList));
+    }
+
+    private BudgetPlanListResponse mapBudgetPlanListToResponseList(List<BudgetPlan> budgetPlanList) {
+        List<BudgetPlanResponse> budgetPlanResponseList = new ArrayList<>();
+        for (BudgetPlan budgetPlan : budgetPlanList) {
+            BudgetPlanResponse budgetPlanResponse = new BudgetPlanResponse(
+                    budgetPlan.getCategory().getId(),
+                    budgetPlan.getCategory().getName().getCategory(),
+                    budgetPlan.getAmount());
+            budgetPlanResponseList.add(budgetPlanResponse);
+        }
+        return new BudgetPlanListResponse(budgetPlanResponseList);
+    }
+
 }


### PR DESCRIPTION
## 작업 내용

사용자가 예산 총액과 함께 카테고리별 금액 추천을 요청할 경우 전체 사용자의 평균 데이터를 기반으로 카테고리별 금액 추천 목록을 반환합니다.
- GET /api/v1/budget-plans/recommendations?amount={amount}

## 작업 설명

- [`cb678c7`](https://github.com/limvik/budget-management-service/commit/cb678c7ee76dee02ddeab5b8c4615886d643cde0)
  - 인증된 사용자가 정상적으로 카테고리별 예산 추천을 요청하는 경우에 대한 테스트입니다.
  - 소수점 단위의 연산으로 정확한 값의 판단이 어려워 뒷 순서의 카테고리일수록 큰 금액을 배정하여, 비율적으로 앞의 카테고리가 적은 값이 추천되는지 여부를 테스트 하였습니다.
- [`9aa2aa1`](https://github.com/limvik/budget-management-service/commit/9aa2aa15d029e460c7783fe1781c6cac611e59a1)
  - 요구사항을 기반으로 전체 평균에서 카테고리별 평균의 비중을 구하였습니다. 도출된 비중에 사용자가 요청 시에 제공한 총 예산을 곱하여 각 카테고리별 추천 금액을 계산하였습니다.
  - 1원 단위는 절삭하였으나, 총액을 맞추기 위해 총액에서 부족한만큼은 `기타` 카테고리에 더하여 1원 단위가 추가될 수 있습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/0430d20e-89c1-4bcf-8bfc-a65afb8aa478)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/bca60aff-115b-4c5e-b9e2-d2df0b077045)

## 기타

- 예상 시간: 2H / 실제 시간: 2H
  - 요구사항이 애매해서 요구사항을 명확하게 하는데 시간이 많이 들어갔습니다. 여전히 애매하지만, 전체 유저를 기반으로한 카테고리별 추천 기능 자체가 임시적인 기능이므로 크게 시간 투자하지 않기로 하였습니다.
  - 이번에는 연산에 JPQL 을 사용하는 것을 처음해봐서, 이리저리 시도해보는데 시간이 예상보다 많이 소모되었습니다.