### PR TITLE
지출 기록 생성 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/category/entity/Category.java
+++ b/src/main/java/com/limvik/econome/domain/category/entity/Category.java
@@ -2,6 +2,7 @@ package com.limvik.econome.domain.category.entity;
 
 import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
 import com.limvik.econome.domain.category.enums.BudgetCategory;
+import com.limvik.econome.domain.expense.entity.Expense;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +29,7 @@ public class Category {
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     private List<BudgetPlan> budgetPlans;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<Expense> expenses;
 }

--- a/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
+++ b/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
@@ -1,0 +1,45 @@
+package com.limvik.econome.domain.expense.entity;
+
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "expenses")
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Instant datetime;
+
+    @Column
+    private long amount;
+
+    @Column(length = 60)
+    private String memo;
+
+    @Column(name = "exclude_in_total")
+    private boolean excluded;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+}

--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -1,0 +1,19 @@
+package com.limvik.econome.domain.expense.service;
+
+import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.infrastructure.expense.ExpenseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+
+    @Transactional
+    public Expense createExpense(Expense expense) {
+        return expenseRepository.save(expense);
+    }
+}

--- a/src/main/java/com/limvik/econome/domain/user/entity/User.java
+++ b/src/main/java/com/limvik/econome/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.limvik.econome.domain.user.entity;
 
 import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.expense.entity.Expense;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -45,5 +46,8 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<BudgetPlan> budgetPlans;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Expense> expenses;
 
 }

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -1,0 +1,8 @@
+package com.limvik.econome.infrastructure.expense;
+
+import com.limvik.econome.domain.expense.entity.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+}

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -1,0 +1,45 @@
+package com.limvik.econome.web.expense.controller;
+
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.expense.service.ExpenseService;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
+import com.limvik.econome.web.expense.dto.ExpenseRequest;
+import com.limvik.econome.web.util.UserUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/expenses")
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @PostMapping
+    public ResponseEntity<String> createExpense(@Valid @RequestBody ExpenseRequest expenseRequest,
+                                                Authentication authentication) {
+        long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
+        Expense createdExpense = expenseService.createExpense(mapRequestToEntity(expenseRequest, userId));
+        return ResponseEntity.created(URI.create("/api/v1/expenses/" + createdExpense.getId())).build();
+    }
+
+    private Expense mapRequestToEntity(ExpenseRequest expenseRequest, long userId) {
+        return Expense.builder()
+                .user(User.builder().id(userId).build())
+                .category(Category.builder().id(expenseRequest.categoryId()).build())
+                .amount(expenseRequest.amount())
+                .memo(expenseRequest.memo())
+                .datetime(expenseRequest.datetime())
+                .build();
+    }
+}

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
@@ -1,0 +1,22 @@
+package com.limvik.econome.web.expense.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record ExpenseRequest(
+
+        @NotNull
+        Instant datetime,
+        @NotNull
+        Long categoryId,
+        @NotNull
+        Long amount,
+        @Length(max = 60)
+        String memo,
+        @JsonProperty(defaultValue = "false")
+        boolean excluded
+) implements Serializable { }


### PR DESCRIPTION
## 작업 내용

지출 일시, 카테고리 식별자, 지출 금액, 메모, 총액 제외 여부를 포함하여 지출 기록을 요청 시 저장하는 기능 및 테스트를 추가하였습니다.

- POST /api/v1/expenses
```json
{
    "datetime": "2023-12-31T12:55:00Z",
    "categoryId": 5,
    "amount": 250000,
    "memo": "맛있는거",
    "excluded": false
}
```

## 작업 설명

- [`cac4308`](https://github.com/limvik/budget-management-service/commit/cac4308d7e49805b6436289ec1c1d1a198c58439)
  - 지출(expense) 데이터 저장을 위한 entity를 추가하고, 외래키인 user_id와 category_id를 지정하기 위해 관계 설정을 수행하였습니다.
- [`4c094dd`](https://github.com/limvik/budget-management-service/commit/4c094ddc5791768103a1c4288a1b90955b9b9076)
  - 인증된 사용자가 정상적인 지출 기록 생성 요청을 하면, `201(Created)` 응답과 `Location` 헤더에 `/api/v1/expenses/{id}` 경로를 반환하는지 테스트를 작성하였습니다.
- [`de14af7`](https://github.com/limvik/budget-management-service/commit/de14af7fccb4c21032b006696d14ef00f1f95583)
  - 특별한 로직은 없으며, 정상적인 요청에 대해 dto에서 entity 로 변환하여 데이터베이스에 저장합니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/1542d1ee-3d13-4576-894b-41f1036a2344)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/6ef0a76b-2cb9-43c9-9311-e500f0f0ce61)

## 기타

- 예상 시간: 1H / 실제 시간: 0.6H
  - 예상보다 조금 빠르기는 했지만, 앞서 소모한 시간이 많아 이 흐름대로 진행 후 시간 내에 기능을 완성하고 남는 시간에 추가적인 리팩토링을 진행하겠습니다.