### PR TITLE
지출 기록 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -1,6 +1,9 @@
 package com.limvik.econome.domain.expense.service;
 
 import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.exception.ErrorException;
 import com.limvik.econome.infrastructure.expense.ExpenseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,5 +18,12 @@ public class ExpenseService {
     @Transactional
     public Expense createExpense(Expense expense) {
         return expenseRepository.save(expense);
+    }
+
+    @Transactional(readOnly = true)
+    public Expense getExpense(long userId, long expenseId) {
+        var user = User.builder().id(userId).build();
+        return expenseRepository.findByUserAndId(user, expenseId).orElseThrow(
+                () -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
     }
 }

--- a/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
+++ b/src/main/java/com/limvik/econome/global/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     NOT_EXIST_USER(HttpStatus.UNAUTHORIZED, "일치하는 사용자 정보가 없습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
     DUPLICATED_BUDGET_PLAN(HttpStatus.CONFLICT, "이미 예산이 설정되었습니다. 원하신다면 수정을 요청해주세요."),
-    NOT_EXIST_BUDGET_PLAN(HttpStatus.NOT_FOUND, "존재하지 않는 예산 계획입니다.");
+    NOT_EXIST_BUDGET_PLAN(HttpStatus.NOT_FOUND, "존재하지 않는 예산 계획입니다."),
+    NOT_EXIST_EXPENSE(HttpStatus.NOT_FOUND, "존재하지 않는 지출입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -1,8 +1,12 @@
 package com.limvik.econome.infrastructure.expense;
 
 import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
+    Optional<Expense> findByUserAndId(User user, long id);
 }

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -6,15 +6,14 @@ import com.limvik.econome.domain.expense.service.ExpenseService;
 import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
 import com.limvik.econome.web.expense.dto.ExpenseRequest;
+import com.limvik.econome.web.expense.dto.ExpenseResponse;
 import com.limvik.econome.web.util.UserUtil;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -41,5 +40,25 @@ public class ExpenseController {
                 .memo(expenseRequest.memo())
                 .datetime(expenseRequest.datetime())
                 .build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ExpenseResponse> getExpense(@Valid @PathVariable(name = "id") @Min(1) long expenseId,
+                                                      Authentication authentication) {
+        long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
+        Expense expense = expenseService.getExpense(userId, expenseId);
+        ExpenseResponse expenseResponse = mapEntityToResponse(expense);
+        return ResponseEntity.ok(expenseResponse);
+    }
+
+    private ExpenseResponse mapEntityToResponse(Expense expense) {
+        return new ExpenseResponse(
+                expense.getId(),
+                expense.getDatetime(),
+                expense.getCategory().getId(),
+                expense.getAmount(),
+                expense.getMemo(),
+                expense.isExcluded()
+        );
     }
 }

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
@@ -1,0 +1,13 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record ExpenseResponse(
+        long id,
+        Instant datetime,
+        long categoryId,
+        long amount,
+        String memo,
+        boolean excluded
+) implements Serializable { }


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 자신의 지출 기록을 상세 조회 요청 시 지출 기록의 모든 정보를 반환하는 기능 및 테스트를 추가하였습니다.
- GET /api/v1/expenses/{id}

|상황|Response Code|Response|
|---|---|---|
|정상적인 지출 상세조회 요청|200(Ok)|지출 기록 상세내용 반환|
|다른 사용자의 지출 기록 상세조회 요청|404(Not Found)|errorCode, errorReason|

### 응답 예시
```json
{
    "id": 3,
    "datetime": "2023-12-31T12:55:00Z",
    "categoryId": 5,
    "amount": 250000,
    "memo": "맛있는거",
    "excluded": false
}
```

## 작업 설명

- [`84e1b23`](https://github.com/limvik/budget-management-service/commit/84e1b23540b8912923bb769e1becab2a4ca7ad29)
  - 인증된 사용자가 정상적으로 자신의 지출 기록을 요청하는 경우 모든 정보를 수신하는지 테스트하였습니다.
- [`aabdd77`](https://github.com/limvik/budget-management-service/commit/aabdd777da8be664f49f6fd456b69d32885cf86a)
  - 인증된 사용자의 id와 지출 기록의 id가 일치하는 기록이 있는 경우 지출 기록을 반환하고, 일치하지 않는 경우 404(Not Found)를 반환하여 사용자 자신의 기록만 조회할 수 있도록 구현하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/f27ad063-27c4-4af5-823e-3f72a87443c8)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/ba171b51-510d-4690-8ffb-41d6c242b3d1)

## 기타

- 예상 시간: 1H / 실제 시간: 0.5H