### PR TITLE
지출기록 수정 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -20,6 +20,14 @@ public class ExpenseService {
         return expenseRepository.save(expense);
     }
 
+    @Transactional
+    public Expense updateExpense(Expense expense) {
+        if (expenseRepository.existsByUserAndId(expense.getUser(), expense.getId()))
+            return expenseRepository.save(expense);
+        else
+            throw new ErrorException(ErrorCode.NOT_EXIST_EXPENSE);
+    }
+
     @Transactional(readOnly = true)
     public Expense getExpense(long userId, long expenseId) {
         var user = User.builder().id(userId).build();

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     Optional<Expense> findByUserAndId(User user, long id);
+
+    boolean existsByUserAndId(User user, long id);
 }

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -28,17 +28,28 @@ public class ExpenseController {
     public ResponseEntity<String> createExpense(@Valid @RequestBody ExpenseRequest expenseRequest,
                                                 Authentication authentication) {
         long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
-        Expense createdExpense = expenseService.createExpense(mapRequestToEntity(expenseRequest, userId));
+        Expense createdExpense = expenseService.createExpense(mapRequestToEntity(expenseRequest, userId, null));
         return ResponseEntity.created(URI.create("/api/v1/expenses/" + createdExpense.getId())).build();
     }
 
-    private Expense mapRequestToEntity(ExpenseRequest expenseRequest, long userId) {
+    @PatchMapping("/{id}")
+    public ResponseEntity<Expense> updateExpense(@Valid @PathVariable(name = "id") @Min(1) Long expenseId,
+                                                @Valid @RequestBody ExpenseRequest expenseRequest,
+                                                Authentication authentication) {
+        long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
+        expenseService.updateExpense(mapRequestToEntity(expenseRequest, userId, expenseId));
+        return ResponseEntity.ok().build();
+    }
+
+    private Expense mapRequestToEntity(ExpenseRequest expenseRequest, Long userId, Long expenseId) {
         return Expense.builder()
+                .id(expenseId)
                 .user(User.builder().id(userId).build())
                 .category(Category.builder().id(expenseRequest.categoryId()).build())
                 .amount(expenseRequest.amount())
                 .memo(expenseRequest.memo())
                 .datetime(expenseRequest.datetime())
+                .excluded(expenseRequest.excluded())
                 .build();
     }
 

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
@@ -1,5 +1,6 @@
 package com.limvik.econome.web.expense.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
@@ -8,15 +9,15 @@ import java.io.Serializable;
 import java.time.Instant;
 
 public record ExpenseRequest(
-
-        @NotNull
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         Instant datetime,
         @NotNull
         Long categoryId,
-        @NotNull
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         Long amount,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         @Length(max = 60)
         String memo,
-        @JsonProperty(defaultValue = "false")
-        boolean excluded
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Boolean excluded
 ) implements Serializable { }


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 자신의 지출 기록을 수정 요청 시 기록을 수정하는 엔드포인트 및 테스트를 추가하였습니다.

|상황|Response Code|Response|
|---|---|---|
|정상적인 지출 수정 요청|200(Ok)|-|
|존재하지 않거나 다른 사용자의 지출 기록 수정 요청|404(Not Found)|errorCode, errorReason|

## 작업 설명

- [`6777937`](https://github.com/limvik/budget-management-service/commit/677793767765d304ab475ec72f18d7c90660b58e)
  - 수정할 지출기록을 저장해두고, 새로운 데이터를 Body에 포함시켜 PATCH 메서드로 보낸 후 동일한 id 의 지출기록 값이 변경되었는지 데이터베이스에서 불러와 확인합니다.
- [`4a16146`](https://github.com/limvik/budget-management-service/commit/4a1614678550587486318cacba057a3363d99c6c)
  - 특별한 로직은 없으며, 수정 요청을 받은 정보를 도메인 객체로 매핑하여 기존 지출 기록의 변경 요청된 내용을 데이터베이스에 기록합니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/ec25bf9f-9696-455f-a1f2-1ab985358733)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/0e98a4e2-21e6-4aca-9429-48b11332fcd0)

## 기타

- 예상 시간: 1H / 실제 시간: 0.7H
  -  request 시 사용하는 DTO 에서 도메인 객체로 매핑할 때 기존의 로직을 그대로 사용했는데, 기존 로직에 지출 id 와 총 합계 제외 여부를 매핑하는 것을 누락하여 수정이 반영되지 않는 문제를 찾는데 시간을 다른 부분보다 더 썼습니다.
  - 간단하게라도 테스트를 작성해서 그나마 빠르게 발견할 수 있었습니다.