### PR TITLE
지출 기록 삭제 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -34,4 +34,12 @@ public class ExpenseService {
         return expenseRepository.findByUserAndId(user, expenseId).orElseThrow(
                 () -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
     }
+
+    @Transactional
+    public void deleteExpense(long userId, long expenseId) {
+        User user = User.builder().id(userId).build();
+        Expense expense = expenseRepository.findByUserAndId(user, expenseId).orElseThrow(
+                () -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
+        expenseRepository.delete(expense);
+    }
 }

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -72,4 +72,12 @@ public class ExpenseController {
                 expense.isExcluded()
         );
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteExpense(@Valid @PathVariable(name = "id") @Min(1) long expenseId,
+                                                Authentication authentication) {
+        long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
+        expenseService.deleteExpense(userId, expenseId);
+        return ResponseEntity.noContent().build();
+    }
 }


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 자신의 지출 기록 삭제 요청 시 지출기록을 삭제하는 엔드포인트 및 테스트를 추가하였습니다.
- DELETE /api/v1/expenses/{id}

|상황|Response Code|Response|
|---|---|---|
|정상적인 지출기록 삭제 요청|204(No Content)|-|
|존재하지 않거나 다른 사용자의 지출기록 삭제 요청|404(Not Found)|errorCode, errorReason|

## 작업 설명
- [`dee29af`](https://github.com/limvik/budget-management-service/commit/dee29afc6a01d73b8611f706c478eade9112b257)
  - 삭제할 지출기록을 저장해두고, 저장한 지출기록의 id와 함께 DELETE 메서드로 삭제를 요청한 후 204(No Content) 반환 및 데이터베이스에서 삭제됐는지 확인합니다.
- [`32dd57`](https://github.com/limvik/budget-management-service/commit/32dd57553113e28a5422b44cffad1611b89949b8)
  - 사용자의 id와 지출기록 id를 이용하여 사용자의 지출기록 존재여부 확인 후 지출기록을 삭제합니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/8b483277-7a0c-4e0b-8d6c-9ebe385eaaad)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/11afef7b-2d69-4624-9a7c-f690e5dfac99)

## 기타

### 시간
- 계획 시간: 1H / 예상 시간: 0.5H / 실제 시간: 0.5H
  - 테스트가 점점 커져서 리팩토링 하려다가 적은 시간에 끝낼 수 있을 것 같지 않아서 일단 기능을 만드는데 집중하였습니다.