### PR TITLE
지출 기록 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class ExpenseService {
@@ -33,6 +37,15 @@ public class ExpenseService {
         var user = User.builder().id(userId).build();
         return expenseRepository.findByUserAndId(user, expenseId).orElseThrow(
                 () -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Expense> getExpenses(long userId, LocalDate startDate, LocalDate endDate, Long minAmount, Long maxAmount) {
+        if (maxAmount <= 0) maxAmount = Long.MAX_VALUE;
+        String startInstant = startDate.toString() + "T00:00:00Z";
+        String postfixForEndInstant = endDate.toString() + "T23:59:59Z";
+        return expenseRepository.findAllExpenseList(userId,
+                Instant.parse(startInstant), Instant.parse(postfixForEndInstant), minAmount, maxAmount);
     }
 
     @Transactional

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -3,7 +3,10 @@ package com.limvik.econome.infrastructure.expense;
 import com.limvik.econome.domain.expense.entity.Expense;
 import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
@@ -11,4 +14,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     Optional<Expense> findByUserAndId(User user, long id);
 
     boolean existsByUserAndId(User user, long id);
+
+    @Query("SELECT e FROM Expense e WHERE e.user.id = ?1 AND e.datetime BETWEEN ?2 AND ?3 AND e.amount BETWEEN ?4 AND ?5")
+    List<Expense> findAllExpenseList(long userId, Instant startDate, Instant endDate, long minAmount, long maxAmount);
 }

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -5,6 +5,7 @@ import com.limvik.econome.domain.expense.entity.Expense;
 import com.limvik.econome.domain.expense.service.ExpenseService;
 import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.global.security.authentication.JwtAuthenticationToken;
+import com.limvik.econome.web.expense.dto.ExpenseListResponse;
 import com.limvik.econome.web.expense.dto.ExpenseRequest;
 import com.limvik.econome.web.expense.dto.ExpenseResponse;
 import com.limvik.econome.web.util.UserUtil;
@@ -16,6 +17,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @RestController
@@ -62,11 +66,81 @@ public class ExpenseController {
         return ResponseEntity.ok(expenseResponse);
     }
 
+    /**
+     * 지정된 기간, 카테고리, 지출금액 범위에 속한 사용자의 모든 지출 기록 리스트를 반환합니다.
+     * 반환되는 항목은 지정한 카테고리만 반환합니다.
+     * 총액 합계에는 지정된 기간의 모든 지출 기록(카테고리 무관)의 지출 합계입니다.
+     * 카테고리별 합계는 총액 합계에서 사용자가 지정한 카테고리의 지출 합계입니다.
+     * @param startDate 시작 일자
+     * @param endDate 종료 일자
+     * @param categoryId 카테고리 식별자
+     * @param minAmount 최소 금액
+     * @param maxAmount 최대 금액
+     * @param authentication 인증된 사용자 정보
+     * @return 지정된 기간, 카테고리, 지출금액 범위에 속한 사용자의 지출 기록 반환
+     */
+    @GetMapping
+    public ResponseEntity<ExpenseListResponse> getExpenseList(@Valid @RequestParam LocalDate startDate,
+                                                              @Valid @RequestParam LocalDate endDate,
+                                                              @Valid @RequestParam Long categoryId,
+                                                              @Valid @Min(0) @RequestParam(required = false, defaultValue = "0") Long minAmount,
+                                                              @Valid @Min(0) @RequestParam(required = false, defaultValue = "0") Long maxAmount,
+                                                              Authentication authentication) {
+        long userId = UserUtil.getUserIdFromJwt((JwtAuthenticationToken) authentication);
+        List<Expense> expenses = expenseService.getExpenses(userId, startDate, endDate, minAmount, maxAmount);
+
+        ExpenseListResponse expenseListResponse = new ExpenseListResponse(
+                mapEntityListToResponseList(expenses, categoryId),
+                getTotalAmount(expenses),
+                getTotalAmountForCategory(expenses, categoryId));
+        return ResponseEntity.ok(expenseListResponse);
+    }
+
+    /**
+     * 사용자가 지정한 기간, 금액의 범위에 포함된 지출 기록과 카테고리 식별자를 받아 지출 기록 반환용 DTO 리스트로 변환하여 반환합니다.
+     * @param expenses 지출 기록 도메인 객체 리스트
+     * @param categoryId 카테고리 식별자
+     * @return 지출 기록 반환용 DTO 리스트 반환
+     */
+    private List<ExpenseResponse> mapEntityListToResponseList(List<Expense> expenses, Long categoryId) {
+        return expenses.stream()
+                .filter(expense -> Objects.equals(expense.getCategory().getId(), categoryId))
+                .map(this::mapEntityToResponse)
+                .toList();
+    }
+
+    /**
+     * 사용자가 지정한 기간, 금액의 범위에 포함된 지출 기록을 받아 합계 제외 항목을 제외한 총액 합계를 반환합니다.
+     * @param expenses 지출 기록 도메인 객체 리스트
+     * @return 합계 제외 항목을 제외한 총액 합계 반환
+     */
+    private long getTotalAmount(List<Expense> expenses) {
+        return expenses.stream()
+                .filter(expense -> !expense.isExcluded())
+                .mapToLong(Expense::getAmount)
+                .sum();
+    }
+
+    /**
+     * 사용자가 지정한 기간, 금액의 범위에 포함된 지출 기록과 카테고리 식별자를 받아
+     * 합계 제외 항목을 제외한 카테고리별 총액 합계를 반환합니다.
+     * @param expenses 지출 기록 도메인 객체 리스트
+     * @param categoryId 카테고리 식별자
+     * @return 합계 제외항목을 제외한 카테고리별 총액 합계 반환
+     */
+    private long getTotalAmountForCategory(List<Expense> expenses, Long categoryId) {
+        return expenses.stream()
+                .filter(expense -> expense.getCategory().getId().equals(categoryId) && !expense.isExcluded())
+                .mapToLong(Expense::getAmount)
+                .sum();
+    }
+
     private ExpenseResponse mapEntityToResponse(Expense expense) {
         return new ExpenseResponse(
                 expense.getId(),
                 expense.getDatetime(),
                 expense.getCategory().getId(),
+                expense.getCategory().getName().getCategory(),
                 expense.getAmount(),
                 expense.getMemo(),
                 expense.isExcluded()

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseListResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseListResponse.java
@@ -1,0 +1,11 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record ExpenseListResponse(
+        List<ExpenseResponse> expenses,
+        Long totalAmount,
+        long totalAmountForCategory
+
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
@@ -1,13 +1,19 @@
 package com.limvik.econome.web.expense.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.io.Serializable;
 import java.time.Instant;
 
 public record ExpenseResponse(
-        long id,
+        Long id,
         Instant datetime,
-        long categoryId,
-        long amount,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        Long categoryId,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        String categoryName,
+        Long amount,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         String memo,
-        boolean excluded
+        Boolean excluded
 ) implements Serializable { }


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 자신의 지출 기록 목록 조회 요청 시 사용자가 지정한 조건에 맞는 지출 기록 목록을 반환하는 엔드포인트 및 테스트를 추가하였습니다.
- GET /api/v1/expenses?startDate={0000-00-00}&endDate={0000-00-00}&categoryId={categoryId}&minAmount={minAmount}&maxAmount={maxAmount}
- minAmount와 maxAmount 는 optional 하고, 나머지는 필수 입니다.

## 작업 설명

- [`aff87a5`](https://github.com/limvik/budget-management-service/commit/aff87a571374b9fc024d911301e2af15042fcbaf)
  - 반복문을 통해 카테고리 id가 1과 2인 데이터를 6개씩 만들었습니다. 그리고 지정된 조건에 맞는 데이터 반환 여부를 테스트합니다.
- [`f8a244d`](https://github.com/limvik/budget-management-service/commit/f8a244d7a77e32a2cfbac42f83697e9f661dc259)
  - 작업 내용
    - 조건에 맞는 모든 목록을 불러와 총액 합계(totalAmount) 및 카테고리별 총액 합계(totalAmountForCategory)를 계산합니다.
    - 반환 시에는 사용자가 요청한 카테고리 id와 일치하는 항목만 반환합니다.
    - 총액 합계는 사용자가 지정한 기간 내 최소/최대 금액 범위 내의 총 합계 금액을 의미합니다. 그리고 제외 요청한 항목은 합계에 포함시키지 않습니다.
  - 문제점 및 향후 계획
    - 모든 데이터를 불러오므로, 굉장히 큰 데이터도 반환할 수 있어 문제가 있습니다.
    - 페이징을 적용해서 큰 데이터 반환을 방지한다고 해도, 모든 데이터를 불러와 합계를 계산하므로 비효율적입니다.
    - 따라서, 데이터베이스에서 직접 계산해서 불러오는 것이 합리적으로 판단되어 수정할 계획입니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/2cdeb45d-862e-4aca-82d2-b104254d1d82)

### 수동 테스트

- 필수 항목 제외하고 조회

![image](https://github.com/limvik/budget-management-service/assets/37972432/2bbdde45-37ca-41b2-ae35-51ec39dcfe9c)

- 최소 금액(minAmount)만 지정하고 조회

![image](https://github.com/limvik/budget-management-service/assets/37972432/38bbe16d-3745-4f55-8554-cfba8b42872c)

## 기타

### 시간

  - 계획 시간: 1H / 예상 시간: 3H / 실제 시간: 3H
    - 예상했던대로 요구사항이 불명확해서 이렇게하는게 맞는지, 저렇게하는게 맞는지 이리저리 생각해보느라 시간이 많이 걸렸습니다.