### PR TITLE
오늘의 추천 지출 금액 조회 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -4,20 +4,27 @@ import com.limvik.econome.domain.expense.entity.Expense;
 import com.limvik.econome.domain.user.entity.User;
 import com.limvik.econome.global.exception.ErrorCode;
 import com.limvik.econome.global.exception.ErrorException;
+import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
 import com.limvik.econome.infrastructure.expense.ExpenseRepository;
+import com.limvik.econome.infrastructure.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 @RequiredArgsConstructor
 @Service
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
+    private final BudgetPlanRepository budgetPlanRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public Expense createExpense(Expense expense) {
@@ -54,5 +61,45 @@ public class ExpenseService {
         Expense expense = expenseRepository.findByUserAndId(user, expenseId).orElseThrow(
                 () -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
         expenseRepository.delete(expense);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Long> getTodayRecommendationExpenses(long userId) {
+        // 사용자 지정 월 예산 불러오기
+        List<Map<String, Long>> monthlyBudget = budgetPlanRepository.findThisMonthBudgetPerCategory(userId);
+        Map<Long, Long> monthlyBudgetMap = new HashMap<>();
+        monthlyBudget.forEach(map -> monthlyBudgetMap.put(map.get("categoryId"), map.get("amount")));
+
+        // 사용자 이번달 카테고리별 지출 합계 불러오기
+        List<Map<String, Long>> monthlyExpenses = expenseRepository.findThisMonthExpensesPerCategory(userId);
+        Map<Long, Long> monthlyExpensesMap = new HashMap<>();
+        monthlyExpenses.forEach(map -> monthlyExpensesMap.put(map.get("categoryId"), map.get("amount")));
+
+        // 카테고리별 추천 금액 계산하기
+        int restDaysOfMonth = LocalDate.now().lengthOfMonth() - LocalDate.now().getDayOfMonth() + 1;
+        long minimumDailyExpense = userRepository.findMinimumDailyExpenseById(userId);
+        long expenseForNotCreatedBudgetPlan = getExpenseForNotCreatedBudgetPlan(monthlyBudgetMap, monthlyExpensesMap);
+        long penaltyForUnexpectedExpensePerCategory = expenseForNotCreatedBudgetPlan / monthlyBudget.size();
+        monthlyBudgetMap.forEach((categoryId, budget) -> {
+            long todayRecommendationAmount = 
+                    (budget - monthlyExpenses.get((int) (categoryId - 1)).get("amount") - penaltyForUnexpectedExpensePerCategory) / restDaysOfMonth / 1000 * 1000;
+            monthlyBudgetMap.put(categoryId, Math.max(todayRecommendationAmount, minimumDailyExpense));
+        });
+        return monthlyBudgetMap;
+    }
+
+    /**
+     * 이번달 카테고리별 예산과 소비 지출 기록을 받아 예산이 설정되지 않은 카테고리에서의 소비 합계를 반환합니다.
+     * @param monthlyBudget 이번달 설정한 카테고리별 예산
+     * @param monthlyExpenses 이번달 소비한 카테고리별 지출 기록
+     * @return 예산이 설정되지 않은 카테고리에서 소비한 금액의 합 반환
+     */
+    private long getExpenseForNotCreatedBudgetPlan(Map<Long, Long> monthlyBudget, Map<Long, Long> monthlyExpenses) {
+        AtomicLong sum = new AtomicLong(0L);
+        monthlyExpenses.forEach((categoryId, amount) -> {
+            if (!monthlyBudget.containsKey(categoryId))
+                sum.addAndGet(monthlyExpenses.get(categoryId));
+        });
+        return sum.get();
     }
 }

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
 
@@ -33,5 +34,13 @@ public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
             "FROM BudgetPlan bp " +
             "GROUP BY bp.category.id, bp.category.name")
     List<BudgetPlan> findRecommendedBudgetPlans(long amount);
+
+    @Query("SELECT new map(bp.category.id as categoryId, sum(bp.amount) as amount) " +
+            "FROM BudgetPlan bp " +
+            "WHERE bp.user.id = ?1 AND " +
+            "FUNCTION('YEAR', bp.date) = FUNCTION('YEAR', CURRENT_DATE) AND " +
+            "FUNCTION('MONTH', bp.date) = FUNCTION('MONTH', CURRENT_DATE) " +
+            "GROUP BY bp.category.id")
+    List<Map<String, Long>> findThisMonthBudgetPerCategory(long userId);
 
 }

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
@@ -17,4 +18,13 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     @Query("SELECT e FROM Expense e WHERE e.user.id = ?1 AND e.datetime BETWEEN ?2 AND ?3 AND e.amount BETWEEN ?4 AND ?5")
     List<Expense> findAllExpenseList(long userId, Instant startDate, Instant endDate, long minAmount, long maxAmount);
+
+    @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
+            "FROM Expense e " +
+            "WHERE e.user.id = ?1 AND " +
+            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', CURRENT_DATE) AND " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', CURRENT_DATE) " +
+            "GROUP BY e.category.id " +
+            "ORDER BY categoryId DESC")
+    List<Map<String, Long>> findThisMonthExpensesPerCategory(long userId);
 }

--- a/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
@@ -2,6 +2,7 @@ package com.limvik.econome.infrastructure.user;
 
 import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByUsername(String username);
     boolean existsByIdAndRefreshToken(Long id, String refreshToken);
+
+    @Query("SELECT u.minimumDailyExpense FROM User u WHERE u.id = ?1")
+    long findMinimumDailyExpenseById(Long id);
 }

--- a/src/main/java/com/limvik/econome/web/expense/dto/RecommendationExpenseListResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/RecommendationExpenseListResponse.java
@@ -1,0 +1,10 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.util.List;
+
+public record RecommendationExpenseListResponse(
+        Long recommendedTodayTotalAmount,
+        String message,
+        List<RecommendationExpenseResponse> recommendations
+) {
+}

--- a/src/main/java/com/limvik/econome/web/expense/dto/RecommendationExpenseResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/RecommendationExpenseResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+
+public record RecommendationExpenseResponse(
+        Long categoryId,
+        String categoryName,
+        Long amount
+) implements Serializable { }

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -96,6 +96,12 @@ class EconomeApplicationTests {
 
 	}
 
+	@AfterAll
+	void tearDown() {
+		budgetPlanRepository.deleteAllInBatch();
+		expenseRepository.deleteAllInBatch();
+	}
+
 	@Test
 	void contextLoads() {
 	}
@@ -336,7 +342,6 @@ class EconomeApplicationTests {
 		HttpEntity<ExpenseRequest> entity = new HttpEntity<>(request, headers);
 		ResponseEntity<String> response = restTemplate.exchange(
 				url, HttpMethod.POST, entity, String.class);
-
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 		assertThat(response.getHeaders().getLocation()).isEqualTo(URI.create(url + "/" + expenseRepository.count()));
 	}

--- a/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
@@ -1,0 +1,158 @@
+package com.limvik.econome;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.category.enums.BudgetCategory;
+import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.config.JwtConfig;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
+import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
+import com.limvik.econome.infrastructure.category.CategoryRepository;
+import com.limvik.econome.infrastructure.expense.ExpenseRepository;
+import com.limvik.econome.infrastructure.user.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EconomeRecommendationTests {
+
+    @Autowired
+    JwtConfig jwtConfig;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    BudgetPlanRepository budgetPlanRepository;
+
+    @Autowired
+    ExpenseRepository expenseRepository;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    User user;
+    String accessToken;
+    String refreshToken;
+
+    @BeforeAll
+    void setup() {
+        // 기본 사용자 테스트 데이터
+        user = User.builder().id(1L)
+                .username("test")
+                .email("test@test.com")
+                .password("$2a$12$jxQoUurwE37F9VBEqtXEtuIfCeJ2aKvY6LkicQ5KFF5.9CZLFeNN6")
+                .minimumDailyExpense(10000)
+                .agreeAlarm(true)
+                .build();
+        accessToken = jwtProvider.generateAccessToken(user);
+        refreshToken = jwtProvider.generateRefreshToken(user);
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+
+    }
+
+    @AfterAll
+    void tearDown() {
+        budgetPlanRepository.deleteAllInBatch();
+        expenseRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("인증된 사용자의 오늘의 추천 지출 금액 조회 요청 - 예산 내 지출")
+    void shouldGetRecommendedExpenseAmountIfValidUser() {
+
+        // 예산 데이터 생성 - 예산이 없는 카테고리의 반환 여부 테스트를 위해 절반의 카테고리만 예산 설정
+        long monthlyBudgetPerCategory = 500000L;
+        int countCreatedBudget = 6;
+        for (long categoryId = 1; categoryId <= countCreatedBudget; categoryId++) {
+            BudgetPlan budgetPlan = BudgetPlan.builder()
+                    .user(user)
+                    .date(LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), 1))
+                    .amount(monthlyBudgetPerCategory)
+                    .category(Category.builder().id(categoryId).build())
+                    .build();
+            budgetPlanRepository.save(budgetPlan);
+        }
+
+        // 지출 데이터 생성 - 예산이 없는 카테고리의 지출도 반영되도록 예산 없는 카테고리 지출 기록 추가
+        int dayOfMonth = LocalDate.now().getDayOfMonth();
+        long dailyExpensePerCategory = 10000L;
+        int countCreatedExpense = countCreatedBudget + 1;
+        var excluded = false;
+        for (int days = 1; days < dayOfMonth; days++) {
+            var datetime = Instant.now().minusSeconds(Duration.ofDays(days).toSeconds());
+            for (long categoryId = 1L; categoryId <= countCreatedExpense; categoryId++) {
+                var expense = Expense.builder().datetime(datetime)
+                        .category(Category.builder().id(categoryId).build())
+                        .amount(dailyExpensePerCategory)
+                        .memo(null)
+                        .excluded(excluded)
+                        .user(user)
+                        .build();
+                expenseRepository.save(expense);
+            }
+        }
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + accessToken);
+        String url = "/api/v1/expenses/recommendations";
+        HttpEntity<String> request = new HttpEntity<>(null, headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                url, HttpMethod.GET, request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        DocumentContext documentContext = JsonPath.parse(response.getBody());
+
+        // 일자별 메시지 확인
+        if (dayOfMonth == 1) {
+            assertThat(documentContext.read("$.message", String.class))
+                    .isEqualTo("1일 이네요! 이번달도 새로운 마음으로 체계적인 지출 도전!");
+        } else {
+            assertThat(documentContext.read("$.message", String.class))
+                    .isEqualTo("오늘도 합리적인 소비 생활 화이팅!");
+        }
+        // 오늘의 추천 총 지출 확인
+        int lengthOfMonth = LocalDate.now().lengthOfMonth();
+        int restDaysOfMonthFromToday = lengthOfMonth - dayOfMonth + 1;
+        long expenseAmount = dailyExpensePerCategory * (dayOfMonth - 1) * countCreatedExpense;
+        long recommendedTodayTotalAmount = (monthlyBudgetPerCategory * countCreatedBudget - expenseAmount) / restDaysOfMonthFromToday / 1000 * 1000;
+        assertThat(documentContext.read("$.recommendedTodayTotalAmount", Long.class))
+                .isEqualTo(recommendedTodayTotalAmount);
+
+        // 카테고리별 추천 지출 확인 - 예산을 설정한 카테고리만 추천하는지 확인
+        assertThat(documentContext.read("$.recommendations.length()", Integer.class)).isEqualTo(countCreatedBudget);
+        for (int i = 0; i < countCreatedBudget; i++) {
+            assertThat(documentContext.read("$.recommendations[%d].categoryId".formatted(i), Long.class))
+                    .isEqualTo(i+1L);
+            assertThat(documentContext.read("$.recommendations[%d].categoryName".formatted(i), String.class))
+                    .isEqualTo(BudgetCategory.values()[i].getCategory());
+            assertThat(documentContext.read("$.recommendations[%d].amount".formatted(i), Long.class))
+                    .isEqualTo(recommendedTodayTotalAmount / countCreatedBudget);
+        }
+
+    }
+}


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 이번달 예산과 소비 지출 기록을 등록해둔 경우 오늘의 지출 추천 금액을 반환하는 엔드포인트 및 테스트를 추가하였습니다.

- GET /api/v1/expenses/recommendations

## 작업 설명

- [`e058c35`](https://github.com/limvik/budget-management-service/commit/e058c3518f801ccf0b697746f920e0ccb18a957f)
  - 인증된 사용자가 6개의 카테고리에 대해 예산을 등록하고, 7개의 카테고리에서 소비한 경우에 대한 테스트 입니다.
  - 예산이 등록된 카테고리에 대해서만 지출 추천 금액을 반환합니다.
  - 예산이 등록되지 않은 카테고리에서의 소비 금액 또한 예산이 등록된 카테고리에 반영하여 추천 지출 금액을 줄입니다.
  - 100원 단위까지는 절삭합니다.
- [`f514296`](https://github.com/limvik/budget-management-service/commit/f514296db90fdbeec9d301f00653ec354a2f284a)
  - 위 테스트를 통과할 수 있는 로직을 작성하였습니다.
  - BudgetPlanRepository 에서 categoryId 별로 합계를 불러고, 마찬가지로 ExpenseRepsitory에서 categoryId 별로 합계를 불러옵니다.
  - 위 데이터를 바탕으로 카테고리별 오늘의 추천 금액을 계산하기 위해 각 카테고리별 두 합계의 차이를 이번달 남은 일수로 나누고, 예산이 배정되지 않은 소비 지출에 의한 소비 감소액은 카테고리별로 균등하게 분배합니다.
  - 만약 카테고리의 추천 금액이 사용자가 설정한 최소 금액보다 낮을 경우에는 최소 금액으로 반환합니다.
  - 오늘이 달의 1일일 경우에는 1일 임을 알리는 메시지, 그 외에는 응원의 메시지를 포함하여 보냅니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/f7d41d82-5590-40c5-8842-66e3da22dcf2)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/c7218690-fa74-4dfd-9d5a-766becbad08b)

## 기타

### 시간 초과

- 계획 시간: 1H / 예상 시간: 3H / 실제 시간: 6H
  - 계획 시간은 이전처럼 테스트 등 별 생각 없이 가용 시간을 분배했습니다.
  - 예상 시간은 요구사항 구체화하는데 2H, 코딩 1H를 예상했습니다.
  - 실제 시간은 요구사항 구체화하는데 3H 정도, 나머지는 테스트 코드 작성 및 로직 작성에 3H 를 사용했습니다.
- 예상 시간 작성할때 까지는 별로 어려운게 아닐거라 생각했는데, 요구사항의 예외적인 경우들을 생각하다보니 고려해야할 사항들이 굉장히 많았습니다. 시간이 너무 초과되어 최소 요구사항은 일단 만족하는 선에서 타협하였습니다.
- 테스트 작성 시에 기대값을 잘못 계산하여 디버깅하는데도 시간이 많이 사용됐습니다.