### PR TITLE
오늘의 총 지출 금액 조회 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -23,8 +23,19 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             "FROM Expense e " +
             "WHERE e.user.id = ?1 AND " +
             "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', CURRENT_DATE) AND " +
-            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', CURRENT_DATE) " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', CURRENT_DATE) AND " +
+            "FUNCTION('DAY', e.datetime) < FUNCTION('DAY', CURRENT_DATE) " +
             "GROUP BY e.category.id " +
             "ORDER BY categoryId DESC")
     List<Map<String, Long>> findThisMonthExpensesPerCategory(long userId);
+
+    @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
+            "FROM Expense e " +
+            "WHERE e.user.id = ?1 AND " +
+            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', CURRENT_DATE) AND " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', CURRENT_DATE) " +
+            "AND FUNCTION('DAY', e.datetime) = FUNCTION('DAY', CURRENT_DATE) " +
+            "GROUP BY e.category.id " +
+            "ORDER BY categoryId DESC")
+    List<Map<String, Long>> findTodayExpensesPerCategory(long userId);
 }

--- a/src/main/java/com/limvik/econome/web/expense/dto/TodayExpenseListResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/TodayExpenseListResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record TodayExpenseListResponse(
+        Long spentTotalAmount,
+        List<TodayExpenseResponse> details
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/expense/dto/TodayExpenseResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/TodayExpenseResponse.java
@@ -1,0 +1,11 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+
+public record TodayExpenseResponse(
+        Long categoryId,
+        String categoryName,
+        Long recommendedAmount,
+        Long spentAmount,
+        String risk
+) implements Serializable { }


### PR DESCRIPTION
## 작업 내용

인증된 사용자가 현재 시간까지 지출한 금액을 요청하는 경우 전체 지출 금액과 카테고리별 지출 금액 그리고 오늘의 추천 소비 금액과 추천 금액 대비 소비 금액을 반환하는 엔드포인트 및 테스트를 추가하였습니다.
- /api/v1/expenses/today
- 응답 예
```json
{
    "spentTotalAmount": 510000,
    "details": [
        {
            "categoryId": 4,
            "categoryName": "주거/수도/광열",
            "recommendedAmount": 78000,
            "spentAmount": 120000,
            "risk": "153%"
        },
        {
            "categoryId": 5,
            "categoryName": "가정용품/가사서비스",
            "recommendedAmount": 93000,
            "spentAmount": 150000,
            "risk": "161%"
        },
        {
            "categoryId": 8,
            "categoryName": "통신",
            "recommendedAmount": 93000,
            "spentAmount": 240000,
            "risk": "258%"
        }
    ]
}
```

## 작업 설명

- [`db47650`](https://github.com/limvik/budget-management-service/commit/db47650edcddbac553f22375cf99c27f8400ffa4)
  - 테스트
  - 소비 추천 기능과 데이터를 공유하여 데이터를 @BeforeAll 에 위치시켰습니다.
  - 테스트 케이스에서는 오늘 지출한 금액을 확인하기 위해 추가적으로 오늘 지출에 대한 테스트 데이터를 추가하였습니다.
  - 총 지출 금액(spentTotalAmount)과 categoryId, categoryName, recommendedAmount, spentAmount, risk 가 정확하게 반환되는지 테스트 합니다.
  - 만약 예산이 배정되지 않은 지출의 경우 recommendedAmount 가 0이고, risk가 0%로 나오는지 테스트 합니다.
- [`1db515c`](https://github.com/limvik/budget-management-service/commit/1db515cb7752bc5cd6e4f76fc9b2a9ca13b8386e)
  - 위 테스트를 통과하도록 로직을 작성하였습니다.
  - 이전 오늘 추천 금액 구하는 로직을 재활용하여, 각 카테고리별로 오늘의 추천 금액을 구하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/ecf8f4b1-74bb-4177-b8d3-16c44dc4dc43)

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/4f567174-62ab-4328-a6f6-381104806d9f)

## 기타

### 시간

  - 계획 시간: 1H / 예상 시간: 2H / 실제 시간: 2H
  - 계산식을 자꾸 헛갈려서 삽질하는데 시간을 가장 많이 썼습니다.

### 배정된 예산 없이 썼는데 risk = 0%?

  - 배정된 예산 없이 소비를 했는데, risk가 0% 라고 표시하는게 어감 상 안맞는거 같습니다.
  - 9999999% 처럼 하자니 너무 장난스러운 느낌입니다.