### PR TITLE
오늘 추천 지출 및 오늘 지출 알림 기능 템플릿 작성

### DIFF
--- a/src/main/java/com/limvik/econome/EconomeApplication.java
+++ b/src/main/java/com/limvik/econome/EconomeApplication.java
@@ -2,7 +2,9 @@ package com.limvik.econome;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class EconomeApplication {
 

--- a/src/main/java/com/limvik/econome/global/config/AppConfig.java
+++ b/src/main/java/com/limvik/econome/global/config/AppConfig.java
@@ -1,0 +1,21 @@
+package com.limvik.econome.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+}

--- a/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/user/UserRepository.java
@@ -4,6 +4,7 @@ import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.minimumDailyExpense FROM User u WHERE u.id = ?1")
     long findMinimumDailyExpenseById(Long id);
+
+    List<User> findAllByAgreeAlarm(boolean agreeAlarm);
 }

--- a/src/main/java/com/limvik/econome/web/expense/task/ExpenseAlarmTask.java
+++ b/src/main/java/com/limvik/econome/web/expense/task/ExpenseAlarmTask.java
@@ -1,0 +1,37 @@
+package com.limvik.econome.web.expense.task;
+
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.infrastructure.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ExpenseAlarmTask {
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+
+    @Scheduled(cron = "0 08 00 * * ?", zone = "Asia/Seoul")
+    public void recommendExpenses() {
+        List<User> users = userRepository.findAllByAgreeAlarm(true);
+        users.forEach(user -> {
+            // TODO: 오늘 추천 지출 알림
+        });
+    }
+
+    @Scheduled(cron = "0 20 00 * * ?", zone = "Asia/Seoul")
+    public void notifyTodayExpenses() {
+        List<User> users = userRepository.findAllByAgreeAlarm(true);
+        users.forEach(user -> {
+            // TODO: 오늘 지출 내역 알림
+        });
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

오늘 추천 지출(08:00) 및 오늘 지출(20:00) 알림 기능을 위한 기본적인 설정을 추가하였습니다.

알림 채널에 따라 메시지를 보내는 형태도 달라져야 하므로, 기본적인 틀만 추가하였습니다.

## 작업 설명

- [`9313d09`](https://github.com/limvik/budget-management-service/commit/9313d098601a798948b3739de95d469b54a51f5a)
  - 요청 시 RestTemplate을 이용하기 위해 설정을 추가하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/0d5a84d5-e3ea-495f-91b1-1db32ef000af)

## 기타

### 시간

- 계획 시간: 1H / 예상 시간: 1H / 실제 시간: 0.2H
  - 테스트라도 작성할까 생각했는데, 알람을 보낼 채널이 정해지지 않으면 의미가 없었습니다.
  - 채널 설정, API 문서 검토, 구현하려면 채널에 따라 다르겠지만, 최소 2H는 걸릴거라 생각됩니다.