### PR TITLE
지출 통계 기능 추가

### DIFF
--- a/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
+++ b/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -23,7 +23,7 @@ public class Expense {
     private Long id;
 
     @Column
-    private Instant datetime;
+    private LocalDateTime datetime;
 
     @Column
     private long amount;

--- a/src/main/java/com/limvik/econome/domain/expense/entity/ExpenseProjection.java
+++ b/src/main/java/com/limvik/econome/domain/expense/entity/ExpenseProjection.java
@@ -1,0 +1,10 @@
+package com.limvik.econome.domain.expense.entity;
+
+public class ExpenseProjection {
+
+    public interface SumCategory {
+        Long getCategoryId();
+        Long getAmount();
+    }
+
+}

--- a/src/main/java/com/limvik/econome/domain/expense/service/dto/CalendarStatDto.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/dto/CalendarStatDto.java
@@ -1,0 +1,14 @@
+package com.limvik.econome.domain.expense.service.dto;
+
+/**
+ * 월간/주간 사용자 지출 통계정보 반환시 Service L에서 Controller로 데이터를 보내기 위한 DTO 입니다.
+ * @param categoryId 카테고리 식별자
+ * @param categoryName 카테고리 이름
+ * @param expenseRate 지난 월/주 대비 지출 비율
+ */
+public record CalendarStatDto(
+        Long categoryId,
+        String categoryName,
+        Double expenseRate
+) {
+}

--- a/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/budgetplan/BudgetPlanRepository.java
@@ -38,9 +38,9 @@ public interface BudgetPlanRepository extends JpaRepository<BudgetPlan, Long> {
     @Query("SELECT new map(bp.category.id as categoryId, sum(bp.amount) as amount) " +
             "FROM BudgetPlan bp " +
             "WHERE bp.user.id = ?1 AND " +
-            "FUNCTION('YEAR', bp.date) = FUNCTION('YEAR', CURRENT_DATE) AND " +
-            "FUNCTION('MONTH', bp.date) = FUNCTION('MONTH', CURRENT_DATE) " +
+            "FUNCTION('YEAR', bp.date) = FUNCTION('YEAR', ?2) AND " +
+            "FUNCTION('MONTH', bp.date) = FUNCTION('MONTH', ?2) " +
             "GROUP BY bp.category.id")
-    List<Map<String, Long>> findThisMonthBudgetPerCategory(long userId);
+    List<Map<String, Long>> findThisMonthBudgetPerCategory(long userId, LocalDate date);
 
 }

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -1,11 +1,13 @@
 package com.limvik.econome.infrastructure.expense;
 
 import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.expense.entity.ExpenseProjection;
 import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,4 +40,35 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             "GROUP BY e.category.id " +
             "ORDER BY categoryId DESC")
     List<Map<String, Long>> findTodayExpensesPerCategory(long userId);
+
+    @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
+            "FROM Expense e " +
+            "WHERE e.user.id = ?1 AND " +
+            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', ?2) AND " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', ?2) " +
+            "AND FUNCTION('DAY', e.datetime) <= FUNCTION('DAY', ?2) " +
+            "GROUP BY e.category.id " +
+            "ORDER BY categoryId ASC")
+    List<ExpenseProjection.SumCategory> findMonthlyExpensesPerCategoryByYearAndMonthAndDayBefore(long userId,
+                                                                                                 LocalDate yearMonthDay);
+
+    @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
+            "FROM Expense e " +
+            "WHERE e.user.id = ?1 AND " +
+            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', ?2) AND " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', ?2) AND " +
+            "FUNCTION('DAY', e.datetime) = FUNCTION('DAY', ?2) " +
+            "GROUP BY e.category.id " +
+            "ORDER BY categoryId ASC")
+    List<ExpenseProjection.SumCategory> findWeeklyExpensesPerCategoryByYearAndMonthAndDay(long userId,
+                                                                                          LocalDate yearMonthDay);
+
+    @Query("SELECT sum(userExpense.amount) / sum(otherUserExpense.amount) * 100 as rate " +
+            "FROM Expense userExpense, Expense otherUserExpense " +
+            "WHERE userExpense.user.id = ?1 AND otherUserExpense.user.id != ?1 AND " +
+            "FUNCTION('YEAR', userExpense.datetime) = FUNCTION('YEAR', CURRENT_DATE) AND " +
+            "FUNCTION('MONTH', userExpense.datetime) = FUNCTION('MONTH', CURRENT_DATE) AND " +
+            "FUNCTION('DAY', userExpense.datetime) <= FUNCTION('DAY', CURRENT_DATE)")
+    Double findExpenseRateCompareOtherUser(long userId);
+
 }

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -6,8 +6,8 @@ import com.limvik.econome.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -19,17 +19,17 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     boolean existsByUserAndId(User user, long id);
 
     @Query("SELECT e FROM Expense e WHERE e.user.id = ?1 AND e.datetime BETWEEN ?2 AND ?3 AND e.amount BETWEEN ?4 AND ?5")
-    List<Expense> findAllExpenseList(long userId, Instant startDate, Instant endDate, long minAmount, long maxAmount);
+    List<Expense> findAllExpenseList(long userId, LocalDateTime startDate, LocalDateTime endDate, long minAmount, long maxAmount);
 
     @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
             "FROM Expense e " +
             "WHERE e.user.id = ?1 AND " +
-            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', CURRENT_DATE) AND " +
-            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', CURRENT_DATE) AND " +
-            "FUNCTION('DAY', e.datetime) < FUNCTION('DAY', CURRENT_DATE) " +
+            "FUNCTION('YEAR', e.datetime) = FUNCTION('YEAR', ?2) AND " +
+            "FUNCTION('MONTH', e.datetime) = FUNCTION('MONTH', ?2) AND " +
+            "FUNCTION('DAY', e.datetime) < FUNCTION('DAY', ?2) " +
             "GROUP BY e.category.id " +
             "ORDER BY categoryId DESC")
-    List<Map<String, Long>> findThisMonthExpensesPerCategory(long userId);
+    List<Map<String, Long>> findThisMonthExpensesPerCategory(long userId, LocalDate date);
 
     @Query("SELECT e.category.id as categoryId, sum(e.amount) as amount " +
             "FROM Expense e " +

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -254,10 +254,10 @@ public class ExpenseController {
     private List<ExpenseStatCalendarCategoryResponse> mapCalendarStatDtoToExpenseStatCategoryResponse(
             List<CalendarStatDto> calendarStatDtos){
         List<ExpenseStatCalendarCategoryResponse> againstLast = new ArrayList<>();
-        calendarStatDtos.forEach(monthlyStatDto -> {
-            String expenseRate = monthlyStatDto.expenseRate().longValue() + "%";
+        calendarStatDtos.forEach(statDto -> {
+            String expenseRate = statDto.expenseRate().longValue() + "%";
             againstLast.add(new ExpenseStatCalendarCategoryResponse(
-                    monthlyStatDto.categoryId(), monthlyStatDto.categoryName(), expenseRate));
+                    statDto.categoryId(), statDto.categoryName(), expenseRate));
         });
         return againstLast;
     }

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -166,15 +166,15 @@ public class ExpenseController {
 
     private RecommendationExpenseListResponse mapEntityListToRecommendationResponseList(
             Map<Long, Long> recommendedTodayExpenseAmountPerCategory) {
-        long recommendedTodayTotalAmount = recommendedTodayExpenseAmountPerCategory.values()
-                .stream().reduce(0L, Long::sum);
+
         String message = getRecommendExpenseMessage();
         List<RecommendationExpenseResponse> recommendationExpenseResponse = new ArrayList<>();
         recommendedTodayExpenseAmountPerCategory.forEach((categoryId, amount) -> recommendationExpenseResponse.add(
                 new RecommendationExpenseResponse(categoryId,
                         BudgetCategory.values()[categoryId.intValue() - 1].getCategory(),
                         amount)));
-
+        long recommendedTodayTotalAmount = Math.round(recommendedTodayExpenseAmountPerCategory.values()
+                .stream().reduce(0L, Long::sum)) / 1000 * 1000;
         return new RecommendationExpenseListResponse(
                 recommendedTodayTotalAmount,
                 message,
@@ -210,7 +210,7 @@ public class ExpenseController {
             details.add(new TodayExpenseResponse(
                         categoryId,
                         BudgetCategory.values()[categoryId.intValue() - 1].getCategory(),
-                        recommendedAmount,
+                        recommendedAmount / 1000 * 1000,
                         spentAmount,
                         risk));
         });
@@ -221,7 +221,7 @@ public class ExpenseController {
 
     private String getRisk(long recommendedAmount, long spentAmount) {
         if (recommendedAmount == 0) return "0%";
-        return (long)((double)spentAmount / recommendedAmount * 100) + "%";
+        return Math.round((double)spentAmount / recommendedAmount * 100) + "%";
     }
 
     @GetMapping("/stat")

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseRequest.java
@@ -1,16 +1,15 @@
 package com.limvik.econome.web.expense.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 
 import java.io.Serializable;
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 public record ExpenseRequest(
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        Instant datetime,
+        LocalDateTime datetime,
         @NotNull
         Long categoryId,
         @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseResponse.java
@@ -3,11 +3,11 @@ package com.limvik.econome.web.expense.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.io.Serializable;
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 public record ExpenseResponse(
         Long id,
-        Instant datetime,
+        LocalDateTime datetime,
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         Long categoryId,
         @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatCalendarCategoryResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatCalendarCategoryResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+
+public record ExpenseStatCalendarCategoryResponse(
+        Long categoryId,
+        String categoryName,
+        String expenseRate
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatCalendarResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatCalendarResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record ExpenseStatCalendarResponse(
+        String totalExpenseRate,
+        List<ExpenseStatCalendarCategoryResponse> details
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatResponse.java
@@ -1,0 +1,9 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+
+public record ExpenseStatResponse(
+        ExpenseStatCalendarResponse againstLastMonth,
+        ExpenseStatCalendarResponse againstLastDayOfWeek,
+        ExpenseStatUserResponse againstOtherUsers
+) implements Serializable { }

--- a/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatUserResponse.java
+++ b/src/main/java/com/limvik/econome/web/expense/dto/ExpenseStatUserResponse.java
@@ -1,0 +1,7 @@
+package com.limvik.econome.web.expense.dto;
+
+import java.io.Serializable;
+
+public record ExpenseStatUserResponse(
+        String relativeExpenseRate
+) implements Serializable { }

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -24,8 +24,9 @@ import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.net.URI;
-import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -336,7 +337,7 @@ class EconomeApplicationTests {
 		String memo = "memo";
 		boolean excluded = false;
 
-		var request = new ExpenseRequest(Instant.parse(datetime), categoryId, amount, memo, excluded);
+		var request = new ExpenseRequest(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME), categoryId, amount, memo, excluded);
 
 		String url = "/api/v1/expenses";
 		HttpEntity<ExpenseRequest> entity = new HttpEntity<>(request, headers);
@@ -349,12 +350,12 @@ class EconomeApplicationTests {
 	@Test
 	@DisplayName("인증된 사용자의 정상적인 지출 기록 상세조회 요청")
 	void shouldGetExpenseIfValidUser() {
-		var datetime = "2023-12-31T09:30:00Z";
+		var datetime = "2023-12-31T09:30:00";
 		var categoryId = 1L;
 		var amount = 100000;
 		var memo = "memo";
 		var excluded = false;
-		var expense = Expense.builder().datetime(Instant.parse(datetime))
+		var expense = Expense.builder().datetime(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME))
 				.category(Category.builder().id(categoryId).build())
 				.amount(amount)
 				.memo(memo)
@@ -390,7 +391,7 @@ class EconomeApplicationTests {
 		var amount = 100000L;
 		var memo = "memo";
 		var excluded = false;
-		var expense = Expense.builder().datetime(Instant.parse(datetime))
+		var expense = Expense.builder().datetime(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME))
 				.category(Category.builder().id(categoryId).build())
 				.amount(amount)
 				.memo(memo)
@@ -403,9 +404,10 @@ class EconomeApplicationTests {
 		var updatedCategoryId = 2L;
 		var updatedAmount = 200000L;
 		var updatedMemo = "updated memo";
-		boolean updatedExcluded = true;
+		var updatedExcluded = true;
+		var parsedDateTime = LocalDateTime.parse(updatedDatetime, DateTimeFormatter.ISO_DATE_TIME);
 		var updateExpenseRequest = new ExpenseRequest(
-				Instant.parse(updatedDatetime), updatedCategoryId, updatedAmount, updatedMemo, updatedExcluded);
+				parsedDateTime, updatedCategoryId, updatedAmount, updatedMemo, updatedExcluded);
 
 		var headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
@@ -418,7 +420,7 @@ class EconomeApplicationTests {
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
 		var updatedExpense = expenseRepository.findById(expense.getId());
-		assertThat(updatedExpense.get().getDatetime()).isEqualTo(Instant.parse(updatedDatetime));
+		assertThat(updatedExpense.get().getDatetime()).isEqualTo(parsedDateTime);
 		assertThat(updatedExpense.get().getAmount()).isEqualTo(updatedAmount);
 		assertThat(updatedExpense.get().getMemo()).isEqualTo(updatedMemo);
 		assertThat(updatedExpense.get().isExcluded()).isEqualTo(updatedExcluded);
@@ -433,7 +435,7 @@ class EconomeApplicationTests {
 		var amount = 100000L;
 		var memo = "memo";
 		var excluded = false;
-		var expense = Expense.builder().datetime(Instant.parse(datetime))
+		var expense = Expense.builder().datetime(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME))
 				.category(Category.builder().id(categoryId).build())
 				.amount(amount)
 				.memo(memo)
@@ -464,7 +466,7 @@ class EconomeApplicationTests {
 			var amount = 10000L * i;
 			var memo = "memo" + i;
 			var excluded = i == 2;
-			var expense = Expense.builder().datetime(Instant.parse(datetime))
+			var expense = Expense.builder().datetime(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME))
 					.category(Category.builder().id(categoryId).build())
 					.amount(amount)
 					.memo(memo)
@@ -489,7 +491,7 @@ class EconomeApplicationTests {
 
 		for (int i = 0; i < 3; i++) {
 			assertThat(documentContext.read("$.expenses[%d].datetime".formatted(i), String.class))
-					.isEqualTo("2023-12-%dT09:%d:00Z".formatted((i+1)*2+10, (i+1)*2+20));
+					.isEqualTo("2023-12-%dT09:%d:00".formatted((i+1)*2+10, (i+1)*2+20));
 			assertThat(documentContext.read("$.expenses[%d].categoryId".formatted(i), Long.class))
 					.isEqualTo(1L);
 			assertThat(documentContext.read("$.expenses[%d].categoryName".formatted(i), String.class))

--- a/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
@@ -143,8 +143,10 @@ public class EconomeRecommendationTests {
         // 오늘의 추천 총 지출 확인
         int lengthOfMonth = LocalDate.now().lengthOfMonth();
         int restDaysOfMonthFromToday = lengthOfMonth - dayOfMonth + 1;
-        long expenseAmount = dailyExpensePerCategory * (dayOfMonth - 1) * countCreatedExpense;
-        long recommendedTodayTotalAmount = (monthlyBudgetPerCategory * countCreatedBudget - expenseAmount) / restDaysOfMonthFromToday / 1000 * 1000;
+        long expenseAmountPerCategory = dailyExpensePerCategory * (dayOfMonth - 1);
+        long penaltyAmountPerCategory = dailyExpensePerCategory * (dayOfMonth - 1) / countCreatedBudget;
+        long RecommendedTodayTotalAmountPerCategory = (monthlyBudgetPerCategory - expenseAmountPerCategory - penaltyAmountPerCategory) / restDaysOfMonthFromToday;
+        long recommendedTodayTotalAmount = (RecommendedTodayTotalAmountPerCategory * countCreatedBudget) / 1000 * 1000;
         assertThat(documentContext.read("$.recommendedTodayTotalAmount", Long.class))
                 .isEqualTo(recommendedTodayTotalAmount);
 


### PR DESCRIPTION
## 작업 내용

사용자가 월간, 주간 상대적 지출 비율 및 다른 사용자와의 상대적 지출 비율을 확인할 수 있는 통계 엔드포인트에 대한 테스트 및 기능을 추가하였습니다.

- GET /api/v1/expenses/stat

## 작업 설명

- [`c476540`](https://github.com/limvik/budget-management-service/commit/c4765407672ce9db586934778db283ff0d3cc3a6)
  - 테스트 데이터로 추가적인 사용자와 해당 사용자의 이번달 소비 지출 금액을 추가하였습니다. 기존에 테스트 데이터로 사용하던 사용자의 소비 지출 금액을 지난달 데이터도 추가하였습니다. 테스트 편의를 위해 두 사용자의 데이터 값은 동일하게 하였습니다.
- [`c3745cc`](https://github.com/limvik/budget-management-service/commit/c3745cc9067d8e7f6b915de6b6fc32ef4aa582b6)
  - 위 테스트를 통과하는 엔드포인트를 추가하였습니다.
  - 지난달 대비 지출 통계: 지난달과 이번달의 동일한 날짜만큼 카테고리별 지출 데이터를 불러온 후 반환 양식에 맞추어 지난달 대비 지출액 비율, 카테고리별 지난달 대비 지출액 비율을 출력합니다.
  - 지난주 대비 지출 통계: 지난달 대비 지출 통계와 동일한 로직으로 지난 주 같은 요일의 데이터를 비교하여 결과를 반환합니다.
  - 다른 사용자와의 상대적 지출 통계: 다른 사용자의 예산 대비 지출 비율과 나의 예산 대비 지출 비율을 비교한 상대적 비율을 반환합니다.
  - 비율 출력 시 소수점은 버립니다.
- [`3a33018`](https://github.com/limvik/budget-management-service/commit/3a33018a54c4683addf937c29778d4a04b2bf62c)
  - 야간에 테스트 수행 중 예상했던 데이터의 갯수만큼 데이터베이스에서 가져오지 못하는 문제가 발견됐습니다.
  - Instant와 LocalDate 및 LocalDateTime을 혼용하여, 한국 시간과 기준 시가 혼용되는 문제였습니다.
  - Instant는 초 단위로만 시간을 제어할 수 있어, LocalDate 및 LocalDateTime으로 모두 변경하였습니다.
- [`9b4389e`](https://github.com/limvik/budget-management-service/commit/9b4389e51b394d36b2ca602f9142dcf2c6070549)
  - 기존의 오늘 지출 추천 금액, 오늘 지출 금액을 조회하는 테스트가 크지 않은 값 차이로 테스트에 실패하는 현상이 발생하였습니다.
  - 통계 기능 추가를 위한 테스트 데이터를 추가하면서 영향을 미쳐, 테스트되지 않던 부분이 테스트가 되는 효과가 있었습니다.
  - 백원단위 절삭을 수행하는 위치가 테스트와 실제 로직이 달라서 발생하는 오류였습니다. 백원단위 절삭의 위치가 다르면, 계산 시 오차가 발생하여 값이 일부 달라지는 문제가 발생합니다. 그래서 Controller 에서만 백원단위 절삭을 수행하도록 변경하였습니다.
- [`c736fee`](https://github.com/limvik/budget-management-service/commit/c736feef5519064c88dcc4c72b55502605b47e8e)
  - 중복 코드를 메서드로 추출하면서, 기존에 사용하던 변수명이 있어 변경하였습니다.

## 테스트

### 통합 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/24fab8f7-28c1-461c-b6e5-3df22447616e)

테스트를 간단하게 하려고, 지난달 데이터를 모두 넣다보니 데이터 삽입에 사용되는 시간이 증가하였습니다.

### 수동 테스트

![image](https://github.com/limvik/budget-management-service/assets/37972432/c823eed3-881d-4aac-a1fb-c0b9cffb12f7)

![image](https://github.com/limvik/budget-management-service/assets/37972432/2efd95c7-adc4-4997-bacd-913b29b6d9c3)

![image](https://github.com/limvik/budget-management-service/assets/37972432/e3689b78-0fc5-4738-bc48-f4b52b7e0073)

## 기타

### 시간 초과

- 계획 시간: 3H / 예상 시간: 3H / 실제 시간 7H
- 기능을 추가하는 시간은 3H 내에 예상대로 했지만, 기존 테스트를 통과하지 못하는 오류를 발견하고 디버깅하는데 시간을 많이 사용했습니다.