### PR TITLE
Branch coverage 개선 85% -> 90%

### DIFF
--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -202,6 +202,26 @@ class EconomeApplicationTests {
 	}
 
 	@Test
+	@DisplayName("데이터베이스에 존재하지 않는 refresh token으로 access token 재발급")
+	void shouldNotReturnAccessTokenIfNotInDatabaseRefreshToken() {
+
+		var headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + jwtProvider.generateRefreshToken(user));
+
+		HttpEntity<String> request = new HttpEntity<>(null, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+				"/api/v1/users/token", HttpMethod.POST, request, String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+		DocumentContext documentContext = JsonPath.parse(response.getBody());
+		assertThat(documentContext.read("$.errorCode", String.class))
+				.isEqualTo(ErrorCode.INVALID_TOKEN.toString());
+		assertThat(documentContext.read("$.errorReason", String.class))
+				.isEqualTo(ErrorCode.INVALID_TOKEN.getMessage());
+	}
+
+	@Test
 	@DisplayName("카테고리 목록 저장 여부 확인")
 	void shouldSaveAllCategoriesInEnum() {
 		List<Category> categories = categoryRepository.findAll();

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -147,11 +147,27 @@ class EconomeApplicationTests {
 	}
 
 	@Test
-	@DisplayName("유효하지 않은 access token으로 엔드포인트 요청")
-	void shouldReturn401UnauthorizedIfNotValidToken() {
-		String invalidAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." +
+	@DisplayName("기한이 지난 access token으로 엔드포인트 요청")
+	void shouldReturn401UnauthorizedIfExpiredToken() {
+		String expiredAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." +
 				"eyJpc3MiOiJsaW12aWtfZWNvbm9tZSIsImlhdCI6MTY5OTY3NDk5NSwiZXhwIjoxNjk5Njc1NTk1LCJzdWIiOiI4In0." +
 				"6uvQXPz8WwXcXoNYBylmS1QWvyfdnjRSbNOg_54aP5g3jWJu7OfVugfuGb14UVJU1umMMj5Nn2KMQn4ASTiYsg";
+
+		var headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Authorization", "Bearer " + expiredAccessToken);
+
+		HttpEntity<String> request = new HttpEntity<>(null, headers);
+		ResponseEntity<String> response = restTemplate.exchange(
+				"/api/v1/test", HttpMethod.POST, request, String.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+	@Test
+	@DisplayName("JWT가 아닌 문자열로 엔드포인트 요청")
+	void shouldReturn401UnauthorizedIfInvalidToken() {
+		String invalidAccessToken = "JWT가.아닌.문자열";
 
 		var headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);


### PR DESCRIPTION
## 작업 내용

- Missed Branch가 현재 120개 중 17개 이고, 90% 이상을 달성하기 위해서는 17개를 12개 이하로 만들어야 합니다.
- 테스트되지 않은 항목 중 개선 대상
  - UsernamePasswordAuthenticationConverter.java 4개
      - getSigninUserInfoFromBody()
          - 사용자 이름과 비밀번호로 로그인 요청 시 HTTP body에 JSON 형식이 옳지 않은 경우
      - isValidUserInfo(), isValidUsername(), isValidPassword()
      - 유효성 검사에 실패한 경우
      - 유효성 검사는 대부분 Validation 라이브러리에 의존하고 있어, 유효성 검사 테스트를 별도로 수행하기 위해 `이번 테스트에서는 제외`
  - ExpenseService.java 1개
    - updateExpense(), getExpense(), deleteExpense()
      - 존재하지 않는 expense인 경우
      - getExpense()와 deleteExpense()는 orElseThrow()를 사용하여 Branch Coverage 측정 대상에 들어가지는 않음 
  - JwtFilter.java 1개
    - doFilterInternal()
      - Token이 JWT 형식이 아니어서 인증에 실패한 경우
  - BudgetPlanService.java 2개
    - createBudgetPlans()
      - 이미 생성된 예산을 생성하는 경우
    - updateBudgetPlans()
      - 존재하지 않는 예산을 수정하는 경우
  - UserController.java 1개
    - 유효한 토큰이지만 데이터베이스에 저장된 refresh token과 다른 경우

## 작업 설명

상황별로 예상한 `HTTP 응답 코드`가 반환되는지, 지정한 `오류 코드` 및 `오류 이유`가 반환되는지 여부를 테스트하였습니다.

## 측정 결과

![image](https://github.com/limvik/budget-management-service/assets/37972432/d8faa18d-976d-4083-94e3-925a5874a272)

## 기타

### 시간

- 예상 시간: 3H / 실제 시간: < 2H
  - 쉬는 시간 1H 생각해서 넉넉하게 잡았는데, 그냥 진행했습니다.