### PR TITLE
Spring REST Docs 를 이용한 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,18 +12,19 @@ java {
 	sourceCompatibility = '17'
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
+}
+
+configurations {
+	asciidoctorExt
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 dependencies {
@@ -43,7 +44,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
@@ -58,5 +60,13 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
 	dependsOn test
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -51,19 +51,22 @@ image::https://user-images.githubusercontent.com/37972432/283320675-26624259-f23
 
 === 사용자
 
-사용자와 관련된 요청을 수행합니다.
+사용자와 관련된 요청에 응답하는 엔드포인트 입니다.
 
 .Users Endpoints
-[cols="1,1"]
+[cols="1,1,2"]
 |===
 | 회원가입
-| `POST /api/v1/users/signup`
+| POST
+| `/api/v1/users/signup`
 
 | 로그인
-| `POST /api/v1/users/signin`
+| POST
+| `/api/v1/users/signin`
 
 | Access Token 갱신
-| `POST /api/v1/users/token`
+| POST
+| `/api/v1/users/token`
 |===
 
 ==== 회원가입
@@ -120,13 +123,109 @@ include::{snippets}/users-token-invalid/http-response.adoc[]
 
 === 예산
 
+사용자의 예산과 관련된 요청에 응답하는 엔드포인트 입니다.
+
+.Budget-Plans Endpoints
+[cols="1,1,2"]
+|===
+| 예산 카테고리 목록 조회
+| GET
+| `/api/v1/categories`
+
+| 예산 설정
+| POST
+| `/api/v1/budget-plans?year=YYYY&month=mm`
+
+| 예산 조회
+| GET
+| `/api/v1/budget-plans?year=YYYY&month=mm`
+
+| 예산 수정
+| PATCH
+| `/api/v1/budget-plans?year=YYYY&month=mm`
+
+| 예산 추천
+| GET
+| `/api/v1/budget-plans/recommendations?budget=budget`
+|===
+
+==== 예산 카테고리 목록 조회
+
+`GET /api/v1/categories`
+
+통계청 가계동향조사에 사용되는 소비지출 12대 비목을 기준으로 선정된 예산 카테고리의 목록을 반환하는 엔드포인트 입니다.
+
+operation::budget-plan-categories[snippets='request-headers,response-fields-beneath-categories,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/budget-plan-categories-unauthorized/http-response.adoc[]
+
 ==== 예산 설정
+
+`POST /api/v1/budget-plans?year=YYYY&month=mm`
+
+사용자가 지정한 연도와 월에 예산을 설정하는 엔드포인트 입니다.
+
+operation::budget-plan-create[snippets='query-parameters,request-headers,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/budget-plan-create-unauthorized/http-response.adoc[]
+
+====== 이미 설정된 예산을 다시 설정 요청하는 경우
+
+include::{snippets}/budget-plan-create-conflict/http-response.adoc[]
 
 ==== 예산 조회
 
+`GET /api/v1/budget-plans?year=YYYY&month=mm`
+
+사용자가 지정한 연도와 월에 설정되어 있는 예산을 전부 조회하는 엔드포인트 입니다.
+
+operation::budget-plan-get[snippets='query-parameters,request-headers,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/budget-plan-get-unauthorized/http-response.adoc[]
+
 ==== 예산 수정
 
+`PATCH /api/v1/budget-plans?year=YYYY&month=mm`
+
+사용자가 지정한 연도와 월에 설정되어 있는 예산을 수정하는 엔드포인트 입니다.
+
+operation::budget-plan-update[snippets='query-parameters,request-headers,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/budget-plan-update-unauthorized/http-response.adoc[]
+
+====== 존재하지 않는 예산을 수정 요청하는 경우
+
+include::{snippets}/budget-plan-update-not-found/http-response.adoc[]
+
 ==== 예산 추천
+
+`GET /api/v1/budget-plans/recommendations?amount=amount`
+
+사용자가 지정한 예산(budget)을 기준으로 다른 사용자의 카테고리별 예산 평균액에 기초한 자료를 요청하는 엔드포인트 입니다.
+
+operation::budget-plan-recommend[snippets='query-parameters,request-headers,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/budget-plan-recommend-unauthorized/http-response.adoc[]
 
 === 지출
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= Econome REST API Reference
+= EconoMe REST API Reference
 Seongguk Jeong <seongguk.dev@gmail.com>
 :description:
 :doctype: book
@@ -12,7 +12,7 @@ image::https://user-images.githubusercontent.com/37972432/283320675-26624259-f23
 
 == 소개
 
-개인의 예산 관리 기능을 제공하는 REST API 입니다. 경제를 의미하는 Economy 에서 개인에 특화된 서비스임을 나타내기 위해 ##EconoMe##로 이름을 지었습니다.
+개인의 예산 관리 기능을 제공하는 서비스의 백엔드 REST API 입니다. 경제를 의미하는 Economy 에서 개인에 특화된 서비스임을 나타내기 위해 ##EconoMe##로 이름을 지었습니다.
 
 - https://github.com/limvik/budget-management-service[GitHub Repository]
 
@@ -30,6 +30,9 @@ image::https://user-images.githubusercontent.com/37972432/283320675-26624259-f23
 
 | 201(Created)
 | 서버에 새로운 데이터를 저장한 경우
+
+| 400(Bad Request)
+| 필요한 Query Parameter를 입력하지 않은 경우
 
 | 401(Unauthorized)
 | 유효하지 않은 토큰 등을 이용하여 인증에 실패한 경우
@@ -97,7 +100,7 @@ operation::users-signin[snippets='request-fields,response-fields,request-body,re
 
 ===== Error Response
 
-====== 존재하지 않는 사용자 이름 또는 비밀번호가 일치하지 않는 경우
+====== 존재하지 않는 사용자 이름 입력 또는 비밀번호가 일치하지 않는 경우
 
 include::{snippets}/users-signin-unauthorized/http-response.adoc[]
 
@@ -229,18 +232,162 @@ include::{snippets}/budget-plan-recommend-unauthorized/http-response.adoc[]
 
 === 지출
 
+사용자의 지출과 관련된 요청에 응답하는 엔드포인트 입니다.
+
+.Expenses Endpoints
+[cols="1,1,2"]
+|===
+| 지출 생성
+| POST
+| `/api/v1/expenses`
+
+| 지출 수정
+| PATCH
+| `/api/v1/expenses/{id}`
+
+| 지출 조회
+| GET
+| `/api/v1/expenses/{id}`
+
+| 지출 삭제
+| DELETE
+| `/api/v1/expenses/{id}`
+
+| 지출 목록 조회
+| GET
+| `/api/v1/expenses?startDate=YYYY-mm-dd&endDate=YYYY-mm-dd&categoryId=categoryId&minAmount=minAmount&maxAmount=maxAmount`
+
+| 오늘 지출 추천
+| GET
+| `/api/v1/expenses/recommendations`
+
+| 오늘의 지출 안내
+| GET
+| `/api/v1/expenses/today`
+
+| 통계
+| GET
+| `/api/v1/expenses/stat`
+|===
+
 ==== 지출 생성
+
+`POST /api/v1/expenses`
+
+사용자의 지출 기록을 ##생성##하는 엔드포인트 입니다.
+
+operation::expense-create[snippets='request-headers,request-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-create-unauthorized/http-response.adoc[]
 
 ==== 지출 수정
 
+`PATCH /api/v1/expenses/{id}`
+
+사용자의 지출 기록을 ##수정##하는 엔드포인트 입니다.
+
+operation::expense-update[snippets='path-parameters,request-headers,request-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-update-unauthorized/http-response.adoc[]
+
+====== 존재하지 않는 지출 기록을 수정 요청하는 경우
+
+include::{snippets}/expense-update-not-found/http-response.adoc[]
+
 ==== 지출 조회
+
+`GET /api/v1/expenses/{id}`
+
+사용자의 지출 기록을 ##조회##하는 엔드포인트 입니다.
+
+operation::expense-get[snippets='path-parameters,request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-get-unauthorized/http-response.adoc[]
+
+====== 존재하지 않는 지출 기록을 조회 요청하는 경우
+
+include::{snippets}/expense-get-not-found/http-response.adoc[]
 
 ==== 지출 삭제
 
+`DELETE /api/v1/expenses/{id}`
+
+사용자의 지출 기록을 ##삭제##하는 엔드포인트 입니다.
+
+operation::expense-delete[snippets='path-parameters,request-headers,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-delete-unauthorized/http-response.adoc[]
+
+====== 존재하지 않는 지출 기록을 삭제 요청하는 경우
+
+include::{snippets}/expense-delete-not-found/http-response.adoc[]
+
 ==== 지출 목록 조회
+
+`GET /api/v1/expenses?startDate=YYYY-mm-dd&endDate=YYYY-mm-dd&categoryId=categoryId&minAmount=minAmount&maxAmount=maxAmount`
+
+사용자의 지출 기록 ##목록##을 ##조회##하는 엔드포인트 입니다.
+
+operation::expense-list[snippets='query-parameters,request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-list-unauthorized/http-response.adoc[]
 
 ==== 오늘 지출 추천
 
+`GET /api/v1/expenses/recommendations`
+
+사용자의 예산을 반영하여 오늘 추천하는 지출 금액을 조회하는 엔드포인트 입니다.
+
+operation::expense-recommendations[snippets='request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
 ==== 오늘의 지출 안내
 
+`GET /api/v1/expenses/today`
+
+사용자의 오늘 소비 지출 내역을 조회하는 엔드포인트 입니다.
+
+operation::expense-today[snippets='request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-today-unauthorized/http-response.adoc[]
+
 ==== 지출 통계
+
+`GET /api/v1/expenses/stat`
+
+사용자의 지난 달/지난 주 대비 지출 비율, 다른 사용자 대비 지출 비율을 조회하는 엔드포인트 입니다.
+
+operation::expense-statistics[snippets='request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Access Token으로 요청하는 경우
+
+include::{snippets}/expense-statistics-unauthorized/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,147 @@
+= Econome REST API Reference
+Seongguk Jeong <seongguk.dev@gmail.com>
+:description:
+:doctype: book
+:toc: left
+:toclevels: 3
+:sectlinks:
+:sectanchors:
+:url-repo: https://github.com/limvik/budget-management-service
+
+image::https://user-images.githubusercontent.com/37972432/283320675-26624259-f239-477f-b230-79b227c2b081.png[econome,align="center"]
+
+== 소개
+
+개인의 예산 관리 기능을 제공하는 REST API 입니다. 경제를 의미하는 Economy 에서 개인에 특화된 서비스임을 나타내기 위해 ##EconoMe##로 이름을 지었습니다.
+
+- https://github.com/limvik/budget-management-service[GitHub Repository]
+
+== 시작하기
+
+`POST /api/v1/users/signup` 에서 회원가입 후 `POST /api/v1/users/signin` 을 통해 로그인하여 인증이 필요한 endpoint 접근을 위한 access key와 refresh key를 얻을 수 있습니다.
+
+== Errors
+
+.Errors
+[cols="1,1"]
+|===
+| 200(Ok)
+| 예상한대로 동작한 경우
+
+| 201(Created)
+| 서버에 새로운 데이터를 저장한 경우
+
+| 401(Unauthorized)
+| 유효하지 않은 토큰 등을 이용하여 인증에 실패한 경우
+
+| 404(Not Found)
+| 존재하지 않는 자원 혹은 자신의 것이 아닌 자원을 요청한 경우
+
+| 409(Conflict)
+| 동일한 자원을 생성한 경우
+
+| 422(Unprocessable Entity)
+| 유효성 검사를 통과하지 못한 경우
+
+| 500(Unprocessable Entity)
+| 유효성 검사를 통과하지 못한 경우
+|===
+
+== 엔드포인트
+
+=== 사용자
+
+사용자와 관련된 요청을 수행합니다.
+
+.Users Endpoints
+[cols="1,1"]
+|===
+| 회원가입
+| `POST /api/v1/users/signup`
+
+| 로그인
+| `POST /api/v1/users/signin`
+
+| Access Token 갱신
+| `POST /api/v1/users/token`
+|===
+
+==== 회원가입
+
+`POST /api/v1/users/signup`
+
+사용자의 회원가입을 수행하는 엔드포인트입니다.
+
+operation::users-signup[snippets='request-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 중복된 사용자 이름 또는 이메일로 회원가입 요청한 경우
+
+include::{snippets}/users-signup-conflict/http-response.adoc[]
+
+====== 유효하지 않은 형식으로 입력하여 회원가입 요청한 경우
+
+include::{snippets}/users-signup-unprocessable/http-response.adoc[]
+
+==== 로그인
+
+`POST /api/v1/users/signin`
+
+회원가입한 사용자가 access token과 refresh token을 얻을 수 있는 엔드포인트 입니다.
+
+operation::users-signin[snippets='request-fields,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 존재하지 않는 사용자 이름 또는 비밀번호가 일치하지 않는 경우
+
+include::{snippets}/users-signin-unauthorized/http-response.adoc[]
+
+====== 유효하지 않은 형식을 입력하여 로그인 요청한 경우
+
+include::{snippets}/users-signin-unprocessable/http-response.adoc[]
+
+==== AccessToken 갱신
+
+`POST /api/v1/users/token`
+
+로그인한 사용자의 Access Token이 만료된 경우, Refresh Token을 이용하여 Access Token을 재발급받을 수 있는 엔드포인트 입니다.
+
+operation::users-token[snippets='request-headers,response-fields,request-body,response-body,http-request,http-response']
+
+===== Error Response
+
+====== 유효하지 않은 Refresh Token으로 요청하는 경우
+
+- 기간만료, 형식오류, 만료되지 않은 과거 Refresh Token 등
+
+include::{snippets}/users-token-invalid/http-response.adoc[]
+
+=== 예산
+
+==== 예산 설정
+
+==== 예산 조회
+
+==== 예산 수정
+
+==== 예산 추천
+
+=== 지출
+
+==== 지출 생성
+
+==== 지출 수정
+
+==== 지출 조회
+
+==== 지출 삭제
+
+==== 지출 목록 조회
+
+==== 오늘 지출 추천
+
+==== 오늘의 지출 안내
+
+==== 지출 통계

--- a/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
+++ b/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
@@ -26,13 +26,13 @@ public class Expense {
     private LocalDateTime datetime;
 
     @Column
-    private long amount;
+    private Long amount;
 
     @Column(length = 60)
     private String memo;
 
     @Column(name = "exclude_in_total")
-    private boolean excluded;
+    private Boolean excluded;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -41,5 +41,23 @@ public class Expense {
     @ManyToOne
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public void update(Expense updateExpense) {
+        if (updateExpense.getDatetime() != null) {
+            this.datetime = updateExpense.getDatetime();
+        }
+        if (updateExpense.getAmount() != null && updateExpense.getAmount() >= 0) {
+            this.amount = updateExpense.getAmount();
+        }
+        if (updateExpense.getMemo() != null) {
+            this.memo = updateExpense.getMemo();
+        }
+        if (updateExpense.getExcluded() != null) {
+            this.excluded = updateExpense.getExcluded();
+        }
+        if (updateExpense.getCategory() != null) {
+            this.category = updateExpense.getCategory();
+        }
+    }
 
 }

--- a/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/limvik/econome/domain/expense/service/ExpenseService.java
@@ -35,11 +35,10 @@ public class ExpenseService {
     }
 
     @Transactional
-    public Expense updateExpense(Expense expense) {
-        if (expenseRepository.existsByUserAndId(expense.getUser(), expense.getId()))
-            return expenseRepository.save(expense);
-        else
-            throw new ErrorException(ErrorCode.NOT_EXIST_EXPENSE);
+    public void updateExpense(Expense updateExpense) {
+        var expense = expenseRepository.findByUserAndId(updateExpense.getUser(), updateExpense.getId())
+                .orElseThrow(() -> new ErrorException(ErrorCode.NOT_EXIST_EXPENSE));
+        expense.update(updateExpense);
     }
 
     @Transactional(readOnly = true)
@@ -142,6 +141,7 @@ public class ExpenseService {
             thisExpenses.stream()
                     .filter(sumCategory -> sumCategory.getCategoryId().equals(lastExpense.getCategoryId()))
                     .findFirst().ifPresent(sumCategory -> thisExpense.set(sumCategory.getAmount()));
+            // 지난 지출이 0일때를 고려하지 않음
             double expenseRate = (double) thisExpense.get() / lastExpense.getAmount() * 100;
             CalendarStatDto dto = new CalendarStatDto(
                     lastExpense.getCategoryId(),

--- a/src/main/java/com/limvik/econome/global/security/jwt/entrypoint/JwtEntryPoint.java
+++ b/src/main/java/com/limvik/econome/global/security/jwt/entrypoint/JwtEntryPoint.java
@@ -5,7 +5,9 @@ import com.limvik.econome.global.exception.ErrorCode;
 import com.limvik.econome.global.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jdk.jfr.ContentType;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -21,6 +23,7 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException) throws IOException {
         response.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer");
         response.setStatus(ErrorCode.INVALID_TOKEN.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         String jsonResponse = new ObjectMapper().writeValueAsString(
                 new ErrorResponse(ErrorCode.INVALID_TOKEN.name(), ErrorCode.INVALID_TOKEN.getMessage()));
         response.getWriter().write(jsonResponse);

--- a/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
+++ b/src/main/java/com/limvik/econome/infrastructure/expense/ExpenseRepository.java
@@ -16,8 +16,6 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     Optional<Expense> findByUserAndId(User user, long id);
 
-    boolean existsByUserAndId(User user, long id);
-
     @Query("SELECT e FROM Expense e WHERE e.user.id = ?1 AND e.datetime BETWEEN ?2 AND ?3 AND e.amount BETWEEN ?4 AND ?5")
     List<Expense> findAllExpenseList(long userId, LocalDateTime startDate, LocalDateTime endDate, long minAmount, long maxAmount);
 

--- a/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
+++ b/src/main/java/com/limvik/econome/web/expense/controller/ExpenseController.java
@@ -118,7 +118,7 @@ public class ExpenseController {
      */
     private long getTotalAmount(List<Expense> expenses) {
         return expenses.stream()
-                .filter(expense -> !expense.isExcluded())
+                .filter(expense -> !expense.getExcluded())
                 .mapToLong(Expense::getAmount)
                 .sum();
     }
@@ -132,7 +132,7 @@ public class ExpenseController {
      */
     private long getTotalAmountForCategory(List<Expense> expenses, Long categoryId) {
         return expenses.stream()
-                .filter(expense -> expense.getCategory().getId().equals(categoryId) && !expense.isExcluded())
+                .filter(expense -> expense.getCategory().getId().equals(categoryId) && !expense.getExcluded())
                 .mapToLong(Expense::getAmount)
                 .sum();
     }
@@ -145,7 +145,7 @@ public class ExpenseController {
                 expense.getCategory().getName().getCategory(),
                 expense.getAmount(),
                 expense.getMemo(),
-                expense.isExcluded()
+                expense.getExcluded()
         );
     }
 

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled("Spring REST Docs 용 테스트로 대체하였습니다.")
 class EconomeApplicationTests {
 
 	@Autowired
@@ -440,6 +441,7 @@ class EconomeApplicationTests {
 		ResponseEntity<String> response = restTemplate.exchange(
 				url, HttpMethod.POST, entity, String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+		expenseRepository.flush();
 		assertThat(response.getHeaders().getLocation()).isEqualTo(URI.create(url + "/" + expenseRepository.count()));
 	}
 
@@ -532,7 +534,7 @@ class EconomeApplicationTests {
 		assertThat(updatedExpense.get().getDatetime()).isEqualTo(parsedDateTime);
 		assertThat(updatedExpense.get().getAmount()).isEqualTo(updatedAmount);
 		assertThat(updatedExpense.get().getMemo()).isEqualTo(updatedMemo);
-		assertThat(updatedExpense.get().isExcluded()).isEqualTo(updatedExcluded);
+		assertThat(updatedExpense.get().getExcluded()).isEqualTo(updatedExcluded);
 
 	}
 

--- a/src/test/java/com/limvik/econome/EconomeApplicationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeApplicationTests.java
@@ -448,7 +448,7 @@ class EconomeApplicationTests {
 	void shouldGetExpenseIfValidUser() {
 		var datetime = "2023-12-31T09:30:00";
 		var categoryId = 1L;
-		var amount = 100000;
+		var amount = 100000L;
 		var memo = "memo";
 		var excluded = false;
 		var expense = Expense.builder().datetime(LocalDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME))

--- a/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
+++ b/src/test/java/com/limvik/econome/EconomeRecommendationTests.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled("Spring REST Docs 용 테스트로 대체하였습니다.")
 public class EconomeRecommendationTests {
 
     @Autowired

--- a/src/test/java/com/limvik/econome/docs/BudgetPlanTest.java
+++ b/src/test/java/com/limvik/econome/docs/BudgetPlanTest.java
@@ -1,0 +1,390 @@
+package com.limvik.econome.docs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.limvik.econome.domain.category.enums.BudgetCategory;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.config.JwtConfig;
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
+import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
+import com.limvik.econome.infrastructure.user.UserRepository;
+import com.limvik.econome.web.budgetplan.dto.BudgetPlanListRequest;
+import com.limvik.econome.web.budgetplan.dto.BudgetPlanListResponse;
+import com.limvik.econome.web.budgetplan.dto.BudgetPlanRequest;
+import com.limvik.econome.web.budgetplan.dto.BudgetPlanResponse;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.headers.RequestHeadersSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.QueryParametersSnippet;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
+@ExtendWith(RestDocumentationExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BudgetPlanTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Autowired
+    JwtConfig jwtConfig;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    BudgetPlanRepository budgetPlanRepository;
+
+    @LocalServerPort
+    int port;
+
+    RequestSpecification spec;
+
+    String accessToken;
+
+    User user;
+
+    int year = 2023;
+    int month = 5;
+    final String BUDGET_PLAN_URL = "/api/v1/budget-plans?year=%d&month=%d".formatted(year, month);
+    final String CATEGORIES_URL = "/api/v1/categories";
+
+    long BUDGET_TOTAL_AMOUNT = 100000L;
+    final String BUDGET_PLAN_RECOMMEND_URL = "/api/v1/budget-plans/recommendations?amount=%d".formatted(BUDGET_TOTAL_AMOUNT);
+
+    final long BUDGET_PLAN_BASE_AMOUNT = 1000;
+
+    @BeforeAll
+    public void init() {
+        user = User.builder()
+                .username("budgetplans")
+                .email("budgetplans@budget.com")
+                .password("budgetplans")
+                .minimumDailyExpense(10000L)
+                .agreeAlarm(false)
+                .build();
+        user = userRepository.save(user);
+
+        this.accessToken = jwtProvider.generateAccessToken(user);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        budgetPlanRepository.deleteAllInBatch();
+        budgetPlanRepository.flush();
+    }
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.spec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(restDocumentation).operationPreprocessors()
+                        .withRequestDefaults(modifyUris().scheme("http").host("econome.com").removePort(), prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .setPort(this.port)
+                .build();
+    }
+
+    @Test
+    @DisplayName("예산 카테고리 목록 조회 성공")
+    void shouldReturnCategoriesListWith200IfValidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-categories", getAccessTokenRequestHeaderSnippet(), getCategoriesResponseFieldsSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(CATEGORIES_URL)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(stringContainsInOrder(getCategories()));
+    }
+
+    @Test
+    @DisplayName("예산 카테고리 목록 조회 실패 - 유효하지 않은 Access Token")
+    void shouldNotReturnCategoriesListWith401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-categories-unauthorized"))
+                    .header("Authorization", "Bearer some.invalid.token")
+                .when()
+                    .get(CATEGORIES_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    private List<String> getCategories() {
+        return Arrays.stream(BudgetCategory.values())
+                .map(BudgetCategory::getCategory)
+                .toList();
+    }
+
+    private ResponseFieldsSnippet getCategoriesResponseFieldsSnippet() {
+        return responseFields(
+                beneathPath("categories"),
+                fieldWithPath("id").description("카테고리 ID"),
+                fieldWithPath("name").description("카테고리 이름")
+        );
+    }
+
+    @Test
+    @DisplayName("예산 설정 성공")
+    void shouldCreateBudgetPlansWithReturn201IfValidToken() throws JsonProcessingException {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-create", getAccessTokenRequestHeaderSnippet(), getBudgetPlanQueryParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getBudgetPlanListRequest(BUDGET_PLAN_BASE_AMOUNT)))
+                .when()
+                    .post(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(HttpStatus.CREATED.value()))
+                    .body(emptyString());
+    }
+
+    @Test
+    @DisplayName("예산 설정 실패 - 유효하지 않은 Access Token")
+    void shouldNotCreateBudgetPlansWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-create-unauthorized"))
+                    .header("Authorization", "Bearer some.invalid.token")
+                .when()
+                    .post(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("예산 설정 실패 - 중복된 예산")
+    void shouldNotCreateBudgetPlansWithReturn409IfDuplicate() throws JsonProcessingException {
+        shouldCreateBudgetPlansWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-create-conflict"))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getBudgetPlanListRequest(BUDGET_PLAN_BASE_AMOUNT)))
+                .when()
+                    .post(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(ErrorCode.DUPLICATED_BUDGET_PLAN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.DUPLICATED_BUDGET_PLAN.name()))
+                    .body("errorReason", is(ErrorCode.DUPLICATED_BUDGET_PLAN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("예산 조회 성공")
+    void shouldReturnBudgetPlansWith200IfValidToken() throws JsonProcessingException {
+        shouldCreateBudgetPlansWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-get", getAccessTokenRequestHeaderSnippet(), getBudgetPlanQueryParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(containsString(objectMapper.writeValueAsString(getBudgetPlanListResponse())));
+    }
+
+    @Test
+    @DisplayName("예산 조회 실패 - 유효하지 않은 Access Token")
+    void shouldNotReturnBudgetPlansWith401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-get-unauthorized"))
+                    .header("Authorization", "Bearer some.invalid.token")
+                .when()
+                    .get(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    private BudgetPlanListResponse getBudgetPlanListResponse() {
+        List<BudgetPlanResponse> budgetPlanResponseList = new ArrayList<>();
+        for (BudgetPlanRequest budgetPlan : getBudgetPlanListRequest(BUDGET_PLAN_BASE_AMOUNT).budgetPlans()) {
+            BudgetPlanResponse budgetPlanResponse = new BudgetPlanResponse(
+                    budgetPlan.categoryId(),
+                    BudgetCategory.values()[(int)budgetPlan.categoryId()-1].getCategory(),
+                    budgetPlan.amount());
+            budgetPlanResponseList.add(budgetPlanResponse);
+        }
+        return new BudgetPlanListResponse(budgetPlanResponseList);
+    }
+
+    @Test
+    @DisplayName("예산 수정 성공")
+    void shouldUpdateBudgetPlansWith200IfValidToken() throws JsonProcessingException {
+        shouldCreateBudgetPlansWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-update", getAccessTokenRequestHeaderSnippet(), getBudgetPlanQueryParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getBudgetPlanListRequest(BUDGET_PLAN_BASE_AMOUNT+1000)))
+                .when()
+                    .patch(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(emptyString());
+    }
+
+    @Test
+    @DisplayName("예산 수정 실패 - 유효하지 않은 Access Token")
+    void shouldNotUpdateBudgetPlansWith401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-update-unauthorized"))
+                    .header("Authorization", "Bearer some.invalid.token")
+                .when()
+                    .patch(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("예산 수정 실패 - 존재하지 않는 예산")
+    void shouldNotUpdateBudgetPlansWith404IfNotExist() throws JsonProcessingException {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-update-not-found"))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getBudgetPlanListRequest(BUDGET_PLAN_BASE_AMOUNT+1000)))
+                .when()
+                    .patch(BUDGET_PLAN_URL)
+                .then()
+                    .statusCode(is(ErrorCode.NOT_EXIST_BUDGET_PLAN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.NOT_EXIST_BUDGET_PLAN.name()))
+                    .body("errorReason", is(ErrorCode.NOT_EXIST_BUDGET_PLAN.getMessage()));
+    }
+
+    private BudgetPlanListRequest getBudgetPlanListRequest(long baseAmount) {
+        List<BudgetPlanRequest> requests = new ArrayList<>();
+        for (long i = 1; i <= BudgetCategory.values().length; i++) {
+            requests.add(new BudgetPlanRequest(i, baseAmount * i));
+        }
+        return new BudgetPlanListRequest(requests);
+    }
+
+    private QueryParametersSnippet getBudgetPlanQueryParametersSnippet() {
+        return queryParameters(
+                parameterWithName("year")
+                        .description("예산 연도"),
+                parameterWithName("month")
+                        .description("예산 월"));
+    }
+
+    @Test
+    @DisplayName("예산 추천 성공")
+    void shouldRecommendBudgetPlansWith200IfValidToken() throws JsonProcessingException {
+        shouldCreateBudgetPlansWithReturn201IfValidToken();
+        JsonPath body = RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-recommend", getAccessTokenRequestHeaderSnippet(), getRecommendBudgetPlanQueryParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(BUDGET_PLAN_RECOMMEND_URL)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                .extract().body().jsonPath();
+        assertThat(getAmountSumFromRecommendedBudget(body)).isEqualTo(BUDGET_TOTAL_AMOUNT);
+    }
+
+    private long getAmountSumFromRecommendedBudget(JsonPath recommendedBudget) {
+        long amountSum = 0;
+        for (int i = 0; i < BudgetCategory.values().length; i++) {
+            amountSum += recommendedBudget.getLong("budgetPlans[" + i + "].amount");
+        }
+        return amountSum;
+    }
+
+    @Test
+    @DisplayName("예산 추천 실패 - 유효하지 않은 Access Token")
+    void shouldNotRecommendBudgetPlansWith401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("budget-plan-recommend-unauthorized"))
+                    .header("Authorization", "Bearer some.invalid.token")
+                .when()
+                    .get(BUDGET_PLAN_RECOMMEND_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    private QueryParametersSnippet getRecommendBudgetPlanQueryParametersSnippet() {
+        return queryParameters(
+                parameterWithName("amount")
+                        .description("예산 금액"));
+    }
+
+    private RequestHeadersSnippet getAccessTokenRequestHeaderSnippet() {
+        return requestHeaders(
+                headerWithName("Authorization")
+                        .description("Bearer JWT(Access Token)"));
+    }
+
+}

--- a/src/test/java/com/limvik/econome/docs/ExpenseTest.java
+++ b/src/test/java/com/limvik/econome/docs/ExpenseTest.java
@@ -1,0 +1,788 @@
+package com.limvik.econome.docs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.limvik.econome.domain.budgetplan.entity.BudgetPlan;
+import com.limvik.econome.domain.category.entity.Category;
+import com.limvik.econome.domain.category.enums.BudgetCategory;
+import com.limvik.econome.domain.expense.entity.Expense;
+import com.limvik.econome.domain.user.entity.User;
+import com.limvik.econome.global.config.JwtConfig;
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
+import com.limvik.econome.infrastructure.budgetplan.BudgetPlanRepository;
+import com.limvik.econome.infrastructure.expense.ExpenseRepository;
+import com.limvik.econome.infrastructure.user.UserRepository;
+import com.limvik.econome.web.expense.dto.*;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.headers.RequestHeadersSnippet;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.PathParametersSnippet;
+import org.springframework.restdocs.request.QueryParametersSnippet;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
+@ExtendWith(RestDocumentationExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ExpenseTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Autowired
+    JwtConfig jwtConfig;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ExpenseRepository expenseRepository;
+
+    @Autowired
+    BudgetPlanRepository budgetPlanRepository;
+
+    @LocalServerPort
+    int port;
+
+    RequestSpecification spec;
+
+    String accessToken;
+
+    User user;
+
+    final int COUNT_CATEGORY = 6;
+
+    final String EXPENSES_URL = "/api/v1/expenses";
+    final String EXPENSES_LIST_QUERY_PARAMS = "?startDate=%s&endDate=%s&categoryId=%d&minAmount=%d&maxAmount=%d";
+    long createdExpenseId;
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.spec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(restDocumentation).operationPreprocessors()
+                        .withRequestDefaults(modifyUris().scheme("http").host("econome.com").removePort(), prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .setPort(this.port)
+                .build();
+    }
+
+    @BeforeAll
+    public void init() {
+        user = User.builder()
+                .username("expensetest")
+                .email("expensetest@expensetest.com")
+                .password("expensetest")
+                .minimumDailyExpense(10000L)
+                .agreeAlarm(false)
+                .build();
+        user = userRepository.save(user);
+
+        this.accessToken = jwtProvider.generateAccessToken(user);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        expenseRepository.deleteAllInBatch();
+        expenseRepository.flush();
+        budgetPlanRepository.deleteAllInBatch();
+        budgetPlanRepository.flush();
+    }
+
+    @AfterAll
+    public void destroy() {
+        userRepository.deleteAllInBatch();
+        userRepository.flush();
+    }
+
+    @Test
+    @DisplayName("지출 생성 성공")
+    void shouldCreateExpenseWithReturn201IfValidToken() throws JsonProcessingException {
+        String createdExpensePath = RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-create", getAccessTokenRequestHeaderSnippet(), getExpenseRequestFields()))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getExpenseRequest()))
+                .when()
+                    .post(EXPENSES_URL)
+                .then()
+                    .statusCode(is(HttpStatus.CREATED.value()))
+                    .body(emptyString())
+                    .header("Location", startsWith(EXPENSES_URL))
+                .extract().header("Location");
+        createdExpenseId = Long.parseLong(createdExpensePath.substring(createdExpensePath.lastIndexOf("/") + 1));
+    }
+
+    @Test
+    @DisplayName("지출 생성 실패 - 유효하지 않은 토큰")
+    void shouldNotCreateExpenseWithReturn401IfInvalidToken() throws JsonProcessingException {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-create-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                    .body(objectMapper.writeValueAsString(getExpenseRequest()))
+                .when()
+                    .post(EXPENSES_URL)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    private ExpenseRequest getExpenseRequest() {
+        return new ExpenseRequest(
+                LocalDateTime.now(),
+                1L,
+                10000L,
+                "memo",
+                false
+        );
+    }
+
+    @Test
+    @DisplayName("지출 수정 성공")
+    void shouldUpdateExpenseWithReturn200IfValidToken() throws JsonProcessingException {
+        shouldCreateExpenseWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-update", getAccessTokenRequestHeaderSnippet(), getExpenseRequestFields(), getExpensePathParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getExpenseUpdateRequest()))
+                .when()
+                    .patch(EXPENSES_URL + "/{id}", createdExpenseId)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(emptyString());
+    }
+
+    @Test
+    @DisplayName("지출 수정 실패 - 유효하지 않은 토큰")
+    void shouldNotUpdateExpenseWithReturn401IfInvalidToken() throws JsonProcessingException {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-update-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                    .body(objectMapper.writeValueAsString(getExpenseUpdateRequest()))
+                .when()
+                    .patch(EXPENSES_URL + "/{id}", createdExpenseId)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("지출 수정 실패 - 존재하지 않는 지출")
+    void shouldNotUpdateExpenseWithReturn404IfNotExistExpense() throws JsonProcessingException {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-update-not-found"))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .body(objectMapper.writeValueAsString(getExpenseUpdateRequest()))
+                .when()
+                    .patch(EXPENSES_URL + "/{id}", 999999)
+                .then()
+                    .statusCode(is(ErrorCode.NOT_EXIST_EXPENSE.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.NOT_EXIST_EXPENSE.name()))
+                    .body("errorReason", is(ErrorCode.NOT_EXIST_EXPENSE.getMessage()));
+    }
+
+    private ExpenseRequest getExpenseUpdateRequest() {
+        return new ExpenseRequest(
+                LocalDateTime.now(),
+                2L,
+                20000L,
+                "22222",
+                true
+        );
+    }
+
+    private RequestFieldsSnippet getExpenseRequestFields() {
+        return requestFields(
+                fieldWithPath("datetime")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 일시")
+                        .attributes(key("constraints").value("Nullable")),
+                fieldWithPath("categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id")
+                        .attributes(key("constraints").value("Not Null\n카테고리에 해당하는 id만 사용 가능. 예산 카테고리 목록 조회 엔드포인트 참고.")),
+                fieldWithPath("amount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 금액")
+                        .attributes(key("constraints").value("Nullable\n최소 0 이상")),
+                fieldWithPath("memo")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 메모")
+                        .attributes(key("constraints").value("Nullable\n최대 60 글자")),
+                fieldWithPath("excluded")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("지출 총액 제외 여부")
+                        .attributes(key("constraints").value("Nullable")));
+    }
+
+    @Test
+    @DisplayName("지출 조회 성공")
+    void shouldGetExpenseWithReturn200IfValidToken() throws JsonProcessingException {
+        shouldCreateExpenseWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-get", getAccessTokenRequestHeaderSnippet(), getExpenseResponseFields(), getExpensePathParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + "/{id}", createdExpenseId)
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(is(objectMapper.writeValueAsString(getExpenseResponse())));
+    }
+
+    private ResponseFieldsSnippet getExpenseResponseFields() {
+        return responseFields(
+                fieldWithPath("id")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 id"),
+                fieldWithPath("datetime")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 일시"),
+                fieldWithPath("categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("amount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 금액"),
+                fieldWithPath("memo")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 메모"),
+                fieldWithPath("excluded")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("지출 총액 제외 여부"));
+    }
+
+    private ExpenseResponse getExpenseResponse() {
+        var expenseRequest = getExpenseRequest();
+        return new ExpenseResponse(
+                createdExpenseId,
+                LocalDateTime.parse(expenseRequest.datetime().minusNanos(25000).toString().substring(0, expenseRequest.datetime().toString().lastIndexOf("."))),
+                expenseRequest.categoryId(),
+                BudgetCategory.values()[(int)(expenseRequest.categoryId() - 1)].getCategory(),
+                expenseRequest.amount(),
+                expenseRequest.memo(),
+                expenseRequest.excluded()
+        );
+    }
+
+    @Test
+    @DisplayName("지출 조회 실패 - 유효하지 않은 토큰")
+    void shouldNotGetExpenseWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-get-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .get(EXPENSES_URL + "/{id}", 999999)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("지출 조회 실패 - 존재하지 않는 지출")
+    void shouldNotGetExpenseWithReturn404IfNotExistExpense() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-get-not-found"))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + "/{id}", 999999)
+                .then()
+                    .statusCode(is(ErrorCode.NOT_EXIST_EXPENSE.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.NOT_EXIST_EXPENSE.name()))
+                    .body("errorReason", is(ErrorCode.NOT_EXIST_EXPENSE.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("지출 삭제 성공")
+    void shouldDeleteExpenseWithReturn204IfValidToken() throws JsonProcessingException {
+        shouldCreateExpenseWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-delete", getAccessTokenRequestHeaderSnippet(), getExpensePathParametersSnippet()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .delete(EXPENSES_URL + "/{id}", createdExpenseId)
+                .then()
+                    .statusCode(is(HttpStatus.NO_CONTENT.value()))
+                    .body(emptyString());
+    }
+
+    @Test
+    @DisplayName("지출 삭제 실패 - 유효하지 않은 토큰")
+    void shouldNotDeleteExpenseWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-delete-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .delete(EXPENSES_URL + "/{id}", 999999)
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("지출 삭제 실패 - 존재하지 않는 지출")
+    void shouldNotDeleteExpenseWithReturn404IfNotExistExpense() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-delete-not-found"))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .delete(EXPENSES_URL + "/{id}", 999999)
+                .then()
+                    .statusCode(is(ErrorCode.NOT_EXIST_EXPENSE.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.NOT_EXIST_EXPENSE.name()))
+                    .body("errorReason", is(ErrorCode.NOT_EXIST_EXPENSE.getMessage()));;
+    }
+
+    private PathParametersSnippet getExpensePathParametersSnippet() {
+        return pathParameters(
+                parameterWithName("id")
+                        .description("지출 id"));
+    }
+
+    @Test
+    @DisplayName("지출 목록 조회 성공")
+    void shouldGetExpenseListWithReturn200IfValidToken() throws JsonProcessingException {
+        shouldCreateExpenseWithReturn201IfValidToken();
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-list", getAccessTokenRequestHeaderSnippet(), getExpenseListQueryParametersSnippet(), getExpenseListResponseFields()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + EXPENSES_LIST_QUERY_PARAMS.formatted(LocalDate.now().toString(), LocalDate.now().toString(), getExpenseRequest().categoryId(), 0, 99999))
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(is(objectMapper.writeValueAsString(getExpenseListResponse())));
+    }
+
+    private QueryParametersSnippet getExpenseListQueryParametersSnippet() {
+        return queryParameters(
+                parameterWithName("startDate")
+                        .description("조회 범위 시작 연월일"),
+                parameterWithName("endDate")
+                        .description("조회 범위 마지막 연월일"),
+                parameterWithName("categoryId")
+                        .description("조회 대상 카테고리 id"),
+                parameterWithName("minAmount")
+                        .description("조회 대상 지출 최소 금액"),
+                parameterWithName("maxAmount")
+                        .description("조회 대상 지출 최대 금액"));
+    }
+
+    private ResponseFieldsSnippet getExpenseListResponseFields() {
+        return responseFields(
+                fieldWithPath("expenses[].id")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 id"),
+                fieldWithPath("expenses[].datetime")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 일시"),
+                fieldWithPath("expenses[].categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("expenses[].categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("expenses[].amount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 금액"),
+                fieldWithPath("expenses[].memo")
+                        .type(JsonFieldType.STRING)
+                        .description("지출 메모"),
+                fieldWithPath("expenses[].excluded")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("지출 총액 제외 여부"),
+                fieldWithPath("totalAmount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("기간 내 지출 총액"),
+                fieldWithPath("totalAmountForCategory")
+                        .type(JsonFieldType.NUMBER)
+                        .description("조회한 카테고리의 지출 총액"));
+    }
+
+    private ExpenseListResponse getExpenseListResponse() {
+        var expenseResponse = getExpenseResponse();
+        return new ExpenseListResponse(
+                List.of(expenseResponse),
+                expenseResponse.amount(),
+                expenseResponse.amount()
+        );
+    }
+
+    @Test
+    @DisplayName("지출 목록 조회 실패 - 유효하지 않은 토큰")
+    void shouldNotGetExpenseListWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-list-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .get(EXPENSES_URL + EXPENSES_LIST_QUERY_PARAMS.formatted(LocalDate.now().toString(), LocalDate.now().toString(), getExpenseRequest().categoryId(), 0, 99999))
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("오늘 지출 추천 성공")
+    void shouldGetExpenseRecommendationsWithReturn200IfValidToken() throws JsonProcessingException {
+        createData(user, LocalDate.now().getDayOfMonth() - 1);
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-recommendations", getAccessTokenRequestHeaderSnippet(), getExpenseRecommendationsListResponseFields()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + "/recommendations")
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(is(objectMapper.writeValueAsString(getExpenseRecommendationListResponse())));
+    }
+
+    private ResponseFieldsSnippet getExpenseRecommendationsListResponseFields() {
+        return responseFields(
+                fieldWithPath("recommendedTodayTotalAmount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("추천하는 오늘 총 금액"),
+                fieldWithPath("message")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 응원 메시지"),
+                fieldWithPath("recommendations[].categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("recommendations[].categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("recommendations[].amount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("지출 금액"));
+    }
+
+    private RecommendationExpenseListResponse getExpenseRecommendationListResponse() {
+        return new RecommendationExpenseListResponse(
+                10000L * COUNT_CATEGORY,
+                "오늘도 합리적인 소비 생활 화이팅!",
+                getExpenseRecommendationsResponse()
+        );
+    }
+
+    private List<RecommendationExpenseResponse> getExpenseRecommendationsResponse() {
+        List<RecommendationExpenseResponse> recommendations = new ArrayList<>();
+        for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
+            recommendations.add(new RecommendationExpenseResponse(
+                    categoryId,
+                    BudgetCategory.values()[(int) (categoryId-1)].getCategory(),
+                    10000L));
+        }
+        return recommendations;
+    }
+
+    @Test
+    @DisplayName("오늘 지출 추천 실패 - 유효하지 않은 토큰")
+    void shouldNotGetExpenseRecommendationsWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-recommendations-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .get(EXPENSES_URL + "/recommendations")
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("오늘의 지출 안내 성공")
+    void shouldGetTodayExpenseWithReturn200IfValidToken() throws JsonProcessingException {
+        createData(user, LocalDate.now().getDayOfMonth() - 1);
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-today", getAccessTokenRequestHeaderSnippet(), getTodayExpenseResponseFields()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + "/today")
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(is(objectMapper.writeValueAsString(getTodayExpenseListResponse())));
+    }
+
+    private ResponseFieldsSnippet getTodayExpenseResponseFields() {
+        return responseFields(
+                fieldWithPath("spentTotalAmount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("오늘의 총 지출금액"),
+                fieldWithPath("details[].categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("details[].categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("details[].recommendedAmount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("오늘 추천 금액"),
+                fieldWithPath("details[].spentAmount")
+                        .type(JsonFieldType.NUMBER)
+                        .description("오늘 소비 금액"),
+                fieldWithPath("details[].risk")
+                        .type(JsonFieldType.STRING)
+                        .description("리스크 - 오늘 추천 금액 대비 소비 금액 백분율"));
+    }
+
+    private TodayExpenseListResponse getTodayExpenseListResponse() {
+        return new TodayExpenseListResponse(
+                10000L * COUNT_CATEGORY,
+                getTodayExpenseResponses()
+        );
+    }
+
+    private List<TodayExpenseResponse> getTodayExpenseResponses() {
+        List<TodayExpenseResponse> todayExpenseResponses = new ArrayList<>();
+        for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
+            todayExpenseResponses.add(new TodayExpenseResponse(
+                    categoryId,
+                    BudgetCategory.values()[(int) (categoryId-1)].getCategory(),
+                    10000L,
+                    10000L,
+                    "100%"
+            ));
+        }
+        return todayExpenseResponses;
+    }
+
+    @Test
+    @DisplayName("오늘의 지출 안내 실패 - 유효하지 않은 토큰")
+    void shouldNotGetTodayExpenseWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-today-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .get(EXPENSES_URL + "/today")
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    @Test
+    @DisplayName("지출 통계 조회 성공")
+    void shouldGetExpenseStatisticsWithReturn200IfValidToken() throws JsonProcessingException {
+        createData(user, LocalDate.now().getDayOfMonth() + LocalDate.now().minusMonths(1).lengthOfMonth() - 1);
+        createData(createNewUser(), LocalDate.now().getDayOfMonth() - 1);
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-statistics", getAccessTokenRequestHeaderSnippet(), getExpenseStatisticsResponseFields()))
+                    .header("Authorization", "Bearer " + accessToken)
+                .when()
+                    .get(EXPENSES_URL + "/stat")
+                .then()
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(is(objectMapper.writeValueAsString(getExpenseStatisticsResponse())));
+    }
+
+    private ResponseFieldsSnippet getExpenseStatisticsResponseFields() {
+        return responseFields(
+                fieldWithPath("againstLastMonth.totalExpenseRate")
+                        .type(JsonFieldType.STRING)
+                        .description("지난 달 같은 날까지 소비 대비 이번 달 소비 비율"),
+                fieldWithPath("againstLastMonth.details[].categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("againstLastMonth.details[].categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("againstLastMonth.details[].expenseRate")
+                        .type(JsonFieldType.STRING)
+                        .description("카테고리의 지난 달 같은 날까지 소비 대비 이번 달 소비 비율"),
+                fieldWithPath("againstLastDayOfWeek.totalExpenseRate")
+                        .type(JsonFieldType.STRING)
+                        .description("지난 주 같은 날 소비 대비 오늘 소비 비율"),
+                fieldWithPath("againstLastDayOfWeek.details[].categoryId")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 카테고리 id"),
+                fieldWithPath("againstLastDayOfWeek.details[].categoryName")
+                        .type(JsonFieldType.STRING)
+                        .description("예산 카테고리 이름"),
+                fieldWithPath("againstLastDayOfWeek.details[].expenseRate")
+                        .type(JsonFieldType.STRING)
+                        .description("카테고리의 지난 주 같은 날 소비 대비 오늘 소비 비율"),
+                fieldWithPath("againstOtherUsers.relativeExpenseRate")
+                        .type(JsonFieldType.STRING)
+                        .description("이번 달 다른 유저의 예산 대비 소비 비율 대비 나의 예산 대비 소비 비율"));
+    }
+
+
+    private ExpenseStatResponse getExpenseStatisticsResponse() {
+        return new ExpenseStatResponse(
+                new ExpenseStatCalendarResponse("100%", getAgainstLast()),
+                new ExpenseStatCalendarResponse("100%", getAgainstLast()),
+                new ExpenseStatUserResponse("100%")
+        );
+    }
+
+    private List<ExpenseStatCalendarCategoryResponse> getAgainstLast() {
+        List<ExpenseStatCalendarCategoryResponse> expenseStatCalendarCategoryResponses = new ArrayList<>();
+        for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
+            expenseStatCalendarCategoryResponses.add(new ExpenseStatCalendarCategoryResponse(
+                    categoryId,
+                    BudgetCategory.values()[(int) (categoryId-1)].getCategory(),
+                    "100%"
+            ));
+        }
+        return expenseStatCalendarCategoryResponses;
+    }
+
+    private void createData(User user, int minusDay) {
+        createBudgetPlan(user);
+        createExpensesFromToday(user, minusDay);
+    }
+
+    private User createNewUser() {
+        var newUser = User.builder()
+                .username("expensetest" + new Random().nextInt() % 100)
+                .email("expensetest%d@expensetest.com" + new Random().nextInt())
+                .password("expensetest")
+                .minimumDailyExpense(10000L)
+                .agreeAlarm(false)
+                .build();
+        return userRepository.save(newUser);
+    }
+
+    private void createBudgetPlan(User user) {
+        // 예산이 없는 카테고리의 반환 여부 테스트를 위해 절반의 카테고리만 예산 설정
+        for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
+            BudgetPlan budgetPlan = BudgetPlan.builder()
+                    .user(user)
+                    .date(LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), 1))
+                    .amount(LocalDate.now().lengthOfMonth() * 10000L)
+                    .category(Category.builder().id(categoryId).build())
+                    .build();
+            budgetPlanRepository.save(budgetPlan);
+        }
+    }
+
+    private void createExpensesFromToday(User user, int minusDay) {
+        List<Expense> expenses = new ArrayList<>((LocalDate.now().getDayOfMonth() - 1) * COUNT_CATEGORY);
+        for (int day = 0; day <= minusDay; day++) {
+            for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
+                expenses.add(Expense.builder()
+                        .user(user)
+                        .datetime(LocalDateTime.now().minusDays(day))
+                        .category(Category.builder().id(categoryId).build())
+                        .amount(10000L)
+                        .memo("오늘 지출")
+                        .build());
+            }
+        }
+        expenseRepository.saveAllAndFlush(expenses);
+    }
+
+    @Test
+    @DisplayName("지출 통계 조회 실패 - 유효하지 않은 토큰")
+    void shouldNotGetExpenseStatisticsWithReturn401IfInvalidToken() {
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("expense-statistics-unauthorized"))
+                    .header("Authorization", "Bearer " + "expense.invalid.accessToken")
+                .when()
+                    .get(EXPENSES_URL + "/stat")
+                .then()
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    private RequestHeadersSnippet getAccessTokenRequestHeaderSnippet() {
+        return requestHeaders(
+                headerWithName("Authorization")
+                        .description("Bearer JWT(Access Token)"));
+    }
+
+}

--- a/src/test/java/com/limvik/econome/docs/ExpenseTest.java
+++ b/src/test/java/com/limvik/econome/docs/ExpenseTest.java
@@ -310,7 +310,7 @@ public class ExpenseTest {
         var expenseRequest = getExpenseRequest();
         return new ExpenseResponse(
                 createdExpenseId,
-                LocalDateTime.parse(expenseRequest.datetime().minusNanos(25000).toString().substring(0, expenseRequest.datetime().toString().lastIndexOf("."))),
+                expenseRepository.findById(createdExpenseId).get().getDatetime(),
                 expenseRequest.categoryId(),
                 BudgetCategory.values()[(int)(expenseRequest.categoryId() - 1)].getCategory(),
                 expenseRequest.amount(),

--- a/src/test/java/com/limvik/econome/docs/UserTest.java
+++ b/src/test/java/com/limvik/econome/docs/UserTest.java
@@ -1,0 +1,317 @@
+package com.limvik.econome.docs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.limvik.econome.global.config.JwtConfig;
+import com.limvik.econome.global.exception.ErrorCode;
+import com.limvik.econome.global.security.jwt.provider.JwtProvider;
+import com.limvik.econome.web.user.dto.SigninRequest;
+import com.limvik.econome.web.user.dto.SignupRequest;
+import io.jsonwebtoken.Jwts;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.headers.RequestHeadersSnippet;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.util.Date;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration")
+@ExtendWith(RestDocumentationExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class UserTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Autowired
+    JwtConfig jwtConfig;
+
+    @LocalServerPort
+    int port;
+
+    RequestSpecification spec;
+
+    String username = "restdocs";
+    String password = "restdocs";
+
+    String refreshToken;
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.spec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(restDocumentation).operationPreprocessors()
+                        .withRequestDefaults(modifyUris().scheme("http").host("econome.com").removePort(), prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .setPort(this.port)
+                .build();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("회원가입 성공")
+    void shouldSignupWithReturn201IfValidSignupInfo() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signup", getSignupRequestFields()))
+                .body(objectMapper.writeValueAsString(getSignupRequestBody()))
+                .when()
+                .post("/api/v1/users/signup")
+                .then()
+                .statusCode(is(HttpStatus.CREATED.value()));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("회원가입 실패 - 사용자 이름 중복")
+    void shouldNotSignupWithReturn409IfDuplicatedUsername() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signup-conflict"))
+                .body(objectMapper.writeValueAsString(getSignupRequestBody()))
+                .when()
+                .post("/api/v1/users/signup")
+                .then()
+                .statusCode(is(ErrorCode.DUPLICATED_USERNAME.getHttpStatus().value()))
+                .body("errorCode", is(ErrorCode.DUPLICATED_USERNAME.name()))
+                .body("errorReason", is(ErrorCode.DUPLICATED_USERNAME.getMessage()));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("회원가입 실패 - 잘못된 이메일 형식")
+    void shouldNotSignupWithReturn422IfInvalidEmail() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signup-unprocessable"))
+                .body(objectMapper.writeValueAsString(getUnprocessableSignupRequestBody()))
+                .when()
+                .post("/api/v1/users/signup")
+                .then()
+                .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()));
+    }
+
+    private RequestFieldsSnippet getSignupRequestFields() {
+        return requestFields(
+                fieldWithPath("username")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 이름")
+                        .attributes(key("constraints").value("최대 20글자까지 입력 가능합니다.")),
+                fieldWithPath("email")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 이메일")
+                        .attributes(key("constraints").value("이메일 형식을 만족해야 합니다.")),
+                fieldWithPath("password")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 비밀번호")
+                        .attributes(key("constraints").value("최소 8글자, 최대 64글자까지 입력 가능합니다.")),
+                fieldWithPath("minimumDailyExpense")
+                        .type(JsonFieldType.NUMBER)
+                        .description("예산 추천 시 일일 소비 최소금액")
+                        .attributes(key("constraints").value("양수만 입력할 수 있습니다.")),
+                fieldWithPath("agreeAlarm")
+                        .type(JsonFieldType.BOOLEAN)
+                        .description("오늘 추천 지출(오전 8시) 및 오늘 지출(오후 8시) 알람 동의 여부 / 선택적(Optional)\n기본값 : false")
+                        .attributes(key("constraints").value(""))
+                        .optional());
+    }
+
+    private SignupRequest getSignupRequestBody() {
+        return new SignupRequest(
+                username,
+                "restdocs@restdocs.com",
+                password,
+                10000L,
+                false);
+    }
+
+    private SignupRequest getUnprocessableSignupRequestBody() {
+        return new SignupRequest(
+                username + 2,
+                "XXXXXXXXXXXXXXXXXXXXX",
+                password,
+                10000L,
+                false);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("로그인 성공")
+    void shouldSigninWithReturn200AndTokensIfValidLoginInfo() throws JsonProcessingException {
+        refreshToken = RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signin", getSigninRequestFields(), getSigninResponseFields()))
+                .body(objectMapper.writeValueAsString(getSigninRequestBody()))
+                .when()
+                .post("/api/v1/users/signin")
+                .then()
+                .statusCode(is(HttpStatus.OK.value()))
+                .body(containsString("accessToken"))
+                .body(containsString("refreshToken"))
+                .extract().body().jsonPath().get("refreshToken");
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("로그인 실패 - 일치하는 사용자 정보 없음")
+    void shouldNotSigninWithReturn401IfNoUser() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signin-unauthorized"))
+                .body(objectMapper.writeValueAsString(getNotExistUserSigninRequestBody()))
+                .when()
+                .post("/api/v1/users/signin")
+                .then()
+                .statusCode(is(ErrorCode.NOT_EXIST_USER.getHttpStatus().value()))
+                .body("errorCode", is(ErrorCode.NOT_EXIST_USER.name()))
+                .body("errorReason", is(ErrorCode.NOT_EXIST_USER.getMessage()));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("로그인 실패 - 잘못된 사용자 이름 형식")
+    void shouldNotSigninWithReturn422IfInvalidUsername() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-signin-unprocessable"))
+                .body(objectMapper.writeValueAsString(getUnprocessableSigninRequestBody()))
+                .when()
+                .post("/api/v1/users/signin")
+                .then()
+                .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()))
+                .body("errorCode", is(ErrorCode.UNPROCESSABLE_USERINFO.name()))
+                .body("errorReason", is(ErrorCode.UNPROCESSABLE_USERINFO.getMessage()));
+    }
+
+    private RequestFieldsSnippet getSigninRequestFields() {
+        return requestFields(
+                fieldWithPath("username")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 이름")
+                        .attributes(key("constraints").value("최대 20글자까지 입력 가능합니다.")),
+                fieldWithPath("password")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 비밀번호")
+                        .attributes(key("constraints").value("최소 8글자, 최대 64글자까지 입력 가능합니다.")));
+    }
+
+    private ResponseFieldsSnippet getSigninResponseFields() {
+        return responseFields(
+                fieldWithPath("accessToken")
+                        .type(JsonFieldType.STRING)
+                        .description("인증이 필요한 엔드포인트 요청을 위한 Token"),
+                fieldWithPath("refreshToken")
+                        .type(JsonFieldType.STRING)
+                        .description("사용자 로그인 상태 유지를 위한 Token"));
+    }
+
+    private SigninRequest getSigninRequestBody() {
+        return new SigninRequest(
+                username,
+                password);
+    }
+
+    private SigninRequest getNotExistUserSigninRequestBody() {
+        return new SigninRequest(
+                username + 999,
+                password);
+    }
+
+    private SigninRequest getUnprocessableSigninRequestBody() {
+        return new SigninRequest(
+                username + 99999999999999999L,
+                password);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Access Token 갱신 성공")
+    void shouldRefreshAccessTokenWithReturn200AndNewAccessToken() throws JsonProcessingException {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-token", getRefreshAccessTokenRequestHeader(), getRefreshAccessTokenResponseFields()))
+                .header("Authorization", "Bearer " + refreshToken)
+                .when()
+                .post("/api/v1/users/token")
+                .then()
+                .statusCode(is(HttpStatus.OK.value()))
+                .body(containsString("accessToken"));
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Access Token 갱신 실패 - 데이터베이스와 다른 Refresh Token")
+    void shouldNotRefreshAccessTokenWithReturn401IfInvalidToken() {
+        RestAssured.given(this.spec)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .filter(document("users-token-invalid", getRefreshAccessTokenRequestHeader()))
+                .header("Authorization", "Bearer " + getFakeToken())
+                .when()
+                .post("/api/v1/users/token")
+                .then()
+                .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+    }
+
+    private RequestHeadersSnippet getRefreshAccessTokenRequestHeader() {
+        return requestHeaders(
+                headerWithName("Authorization")
+                        .description("Bearer JWT(Refresh Token)"));
+    }
+
+    private ResponseFieldsSnippet getRefreshAccessTokenResponseFields() {
+        return responseFields(
+                fieldWithPath("accessToken")
+                        .type(JsonFieldType.STRING)
+                        .description("Refresh Token 에 의해 갱신된 Token"));
+    }
+
+    private String getFakeToken() {
+        return Jwts.builder()
+                .header().type("JWT")
+                .and()
+                .issuer(jwtConfig.getIssuer())
+                .issuedAt(new Date())
+                .expiration(new Date(new Date().getTime() + Duration.ofDays(1).toMillis()))
+                .subject("1")
+                .signWith(jwtProvider.getRefreshKey())
+                .compact();
+    }
+}

--- a/src/test/java/com/limvik/econome/docs/UserTest.java
+++ b/src/test/java/com/limvik/econome/docs/UserTest.java
@@ -79,47 +79,50 @@ public class UserTest {
     @Order(1)
     @DisplayName("회원가입 성공")
     void shouldSignupWithReturn201IfValidSignupInfo() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signup", getSignupRequestFields()))
-                .body(objectMapper.writeValueAsString(getSignupRequestBody()))
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signup", getSignupRequestFields()))
+                    .body(objectMapper.writeValueAsString(getSignupRequestBody()))
                 .when()
-                .post("/api/v1/users/signup")
+                    .post("/api/v1/users/signup")
                 .then()
-                .statusCode(is(HttpStatus.CREATED.value()));
+                    .statusCode(is(HttpStatus.CREATED.value()));
     }
 
     @Test
     @Order(2)
     @DisplayName("회원가입 실패 - 사용자 이름 중복")
     void shouldNotSignupWithReturn409IfDuplicatedUsername() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signup-conflict"))
-                .body(objectMapper.writeValueAsString(getSignupRequestBody()))
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signup-conflict"))
+                    .body(objectMapper.writeValueAsString(getSignupRequestBody()))
                 .when()
-                .post("/api/v1/users/signup")
+                    .post("/api/v1/users/signup")
                 .then()
-                .statusCode(is(ErrorCode.DUPLICATED_USERNAME.getHttpStatus().value()))
-                .body("errorCode", is(ErrorCode.DUPLICATED_USERNAME.name()))
-                .body("errorReason", is(ErrorCode.DUPLICATED_USERNAME.getMessage()));
+                    .statusCode(is(ErrorCode.DUPLICATED_USERNAME.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.DUPLICATED_USERNAME.name()))
+                    .body("errorReason", is(ErrorCode.DUPLICATED_USERNAME.getMessage()));
     }
 
     @Test
     @Order(3)
     @DisplayName("회원가입 실패 - 잘못된 이메일 형식")
     void shouldNotSignupWithReturn422IfInvalidEmail() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signup-unprocessable"))
-                .body(objectMapper.writeValueAsString(getUnprocessableSignupRequestBody()))
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signup-unprocessable"))
+                    .body(objectMapper.writeValueAsString(getUnprocessableSignupRequestBody()))
                 .when()
-                .post("/api/v1/users/signup")
+                    .post("/api/v1/users/signup")
                 .then()
-                .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()));
+                    .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()));
     }
 
     private RequestFieldsSnippet getSignupRequestFields() {
@@ -169,52 +172,55 @@ public class UserTest {
     @Order(4)
     @DisplayName("로그인 성공")
     void shouldSigninWithReturn200AndTokensIfValidLoginInfo() throws JsonProcessingException {
-        refreshToken = RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signin", getSigninRequestFields(), getSigninResponseFields()))
-                .body(objectMapper.writeValueAsString(getSigninRequestBody()))
+        refreshToken = RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signin", getSigninRequestFields(), getSigninResponseFields()))
+                    .body(objectMapper.writeValueAsString(getSigninRequestBody()))
                 .when()
-                .post("/api/v1/users/signin")
+                    .post("/api/v1/users/signin")
                 .then()
-                .statusCode(is(HttpStatus.OK.value()))
-                .body(containsString("accessToken"))
-                .body(containsString("refreshToken"))
-                .extract().body().jsonPath().get("refreshToken");
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(containsString("accessToken"))
+                    .body(containsString("refreshToken"))
+                    .extract().body().jsonPath().get("refreshToken");
     }
 
     @Test
     @Order(5)
     @DisplayName("로그인 실패 - 일치하는 사용자 정보 없음")
     void shouldNotSigninWithReturn401IfNoUser() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signin-unauthorized"))
-                .body(objectMapper.writeValueAsString(getNotExistUserSigninRequestBody()))
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signin-unauthorized"))
+                    .body(objectMapper.writeValueAsString(getNotExistUserSigninRequestBody()))
                 .when()
-                .post("/api/v1/users/signin")
+                    .post("/api/v1/users/signin")
                 .then()
-                .statusCode(is(ErrorCode.NOT_EXIST_USER.getHttpStatus().value()))
-                .body("errorCode", is(ErrorCode.NOT_EXIST_USER.name()))
-                .body("errorReason", is(ErrorCode.NOT_EXIST_USER.getMessage()));
+                    .statusCode(is(ErrorCode.NOT_EXIST_USER.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.NOT_EXIST_USER.name()))
+                    .body("errorReason", is(ErrorCode.NOT_EXIST_USER.getMessage()));
     }
 
     @Test
     @Order(6)
     @DisplayName("로그인 실패 - 잘못된 사용자 이름 형식")
     void shouldNotSigninWithReturn422IfInvalidUsername() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-signin-unprocessable"))
-                .body(objectMapper.writeValueAsString(getUnprocessableSigninRequestBody()))
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-signin-unprocessable"))
+                    .body(objectMapper.writeValueAsString(getUnprocessableSigninRequestBody()))
                 .when()
-                .post("/api/v1/users/signin")
+                    .post("/api/v1/users/signin")
                 .then()
-                .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()))
-                .body("errorCode", is(ErrorCode.UNPROCESSABLE_USERINFO.name()))
-                .body("errorReason", is(ErrorCode.UNPROCESSABLE_USERINFO.getMessage()));
+                    .statusCode(is(ErrorCode.UNPROCESSABLE_USERINFO.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.UNPROCESSABLE_USERINFO.name()))
+                    .body("errorReason", is(ErrorCode.UNPROCESSABLE_USERINFO.getMessage()));
     }
 
     private RequestFieldsSnippet getSigninRequestFields() {
@@ -261,33 +267,35 @@ public class UserTest {
     @Order(7)
     @DisplayName("Access Token 갱신 성공")
     void shouldRefreshAccessTokenWithReturn200AndNewAccessToken() throws JsonProcessingException {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-token", getRefreshAccessTokenRequestHeader(), getRefreshAccessTokenResponseFields()))
-                .header("Authorization", "Bearer " + refreshToken)
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-token", getRefreshAccessTokenRequestHeader(), getRefreshAccessTokenResponseFields()))
+                    .header("Authorization", "Bearer " + refreshToken)
                 .when()
-                .post("/api/v1/users/token")
+                    .post("/api/v1/users/token")
                 .then()
-                .statusCode(is(HttpStatus.OK.value()))
-                .body(containsString("accessToken"));
+                    .statusCode(is(HttpStatus.OK.value()))
+                    .body(containsString("accessToken"));
     }
 
     @Test
     @Order(8)
     @DisplayName("Access Token 갱신 실패 - 데이터베이스와 다른 Refresh Token")
     void shouldNotRefreshAccessTokenWithReturn401IfInvalidToken() {
-        RestAssured.given(this.spec)
-                .accept(ContentType.JSON)
-                .contentType(ContentType.JSON)
-                .filter(document("users-token-invalid", getRefreshAccessTokenRequestHeader()))
-                .header("Authorization", "Bearer " + getFakeToken())
+        RestAssured
+                .given(this.spec)
+                    .accept(ContentType.JSON)
+                    .contentType(ContentType.JSON)
+                    .filter(document("users-token-invalid", getRefreshAccessTokenRequestHeader()))
+                    .header("Authorization", "Bearer " + getFakeToken())
                 .when()
-                .post("/api/v1/users/token")
+                    .post("/api/v1/users/token")
                 .then()
-                .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
-                .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
-                .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
+                    .statusCode(is(ErrorCode.INVALID_TOKEN.getHttpStatus().value()))
+                    .body("errorCode", is(ErrorCode.INVALID_TOKEN.name()))
+                    .body("errorReason", is(ErrorCode.INVALID_TOKEN.getMessage()));;
     }
 
     private RequestHeadersSnippet getRefreshAccessTokenRequestHeader() {

--- a/src/test/java/com/limvik/econome/web/user/controller/UserSigninControllerTest.java
+++ b/src/test/java/com/limvik/econome/web/user/controller/UserSigninControllerTest.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/limvik/econome/web/user/controller/UserSignupControllerTest.java
+++ b/src/test/java/com/limvik/econome/web/user/controller/UserSignupControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = UserController.class)

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|Path|Type|Description|Constraints
+
+{{#fields}}
+|{{path}}
+|{{type}}
+|{{description}}
+|{{constraints}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## 작업 내용

Spring REST Docs 를 이용하여 API를 문서화 하였습니다.

![image](https://github.com/limvik/budget-management-service/assets/37972432/8b4edbfa-afc6-4329-a075-22b64274118d)

## 작업 설명

### MockMvc vs RestAssured

테스트 작성 시에는 MockMvc와 RestAssured 중에서 고민하다가 `RestAssured`로 하였습니다. Spring REST Docs를 선택하는 이유가 테스트를 통해 검증된 API 를 사용할 수 있다는 점인데, MockMvc를 사용하여 일부 로직을 Mocking 해서 테스트 한다는게 말이 안맞는거 같아서 RestAssured를 사용했습니다.

### 오류 수정

- [`ec0dfe4`](https://github.com/limvik/budget-management-service/commit/ec0dfe4f4076708e49879e43626e877e8d31c162)
  - 토큰 인증 실패 시 EntryPoint에서 response를 작성할 때, ContentType을 지정하지 않아 테스트 중 오류를 발견하였습니다. JSON으로 명확하게 지정하여 오류가 발생하지 않도록 수정하였습니다.
- [`c2da713`](https://github.com/limvik/budget-management-service/commit/c2da7136651ed42591b027d1c84cff7f5312400f)
  - Entity는 자료형을 원시형을 사용하고, DTO는 wrapper 클래스를 사용하여, null이 있는 경우 mapping 작업 시에 오류가 발생했습니다. null을 위한 별도의 처리를 하는 것 보다는 Entity에서 Wrapper 클래스를 사용하는 것이 코드 가독성을 판단하기에 좋을 것으로 판단되어 Wrapper 클래스로 통일하였습니다. 그리고 Wrapper 클래스로 변경으로 인한 영향을 받는 코드들이 동작하도록 수정하였습니다.

## 기타

### 시간

- 예상 시간: 12H / 측정 시간: 10.5H
  - 측정하지 않았던 시간들까지 합치면 아마 12H는 넘을 것으로 생각됩니다.