### PR TITLE
테스트 속도 개선

### DIFF
--- a/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
+++ b/src/main/java/com/limvik/econome/domain/budgetplan/entity/BudgetPlan.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 public class BudgetPlan {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/limvik/econome/domain/category/entity/Category.java
+++ b/src/main/java/com/limvik/econome/domain/category/entity/Category.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class Category {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
+++ b/src/main/java/com/limvik/econome/domain/expense/entity/Expense.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 public class Expense {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column

--- a/src/main/java/com/limvik/econome/domain/user/entity/User.java
+++ b/src/main/java/com/limvik/econome/domain/user/entity/User.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
     @Column(unique = true, length = 20)

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -1,5 +1,5 @@
 spring:
   datasource:
-    url: jdbc:tc:mysql:8.0.35:///?user=root?password=test
+    url: jdbc:tc:mysql:8.0.35:///?user=root?password=test?rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=999999
   flyway:
     skip-default-callbacks: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        hbm2ddl:
+          auto: create
+        jdbc:
+          batch_size: 100
 
 jwt:
   issuer: ${JWT_ISSUER}

--- a/src/test/java/com/limvik/econome/docs/ExpenseTest.java
+++ b/src/test/java/com/limvik/econome/docs/ExpenseTest.java
@@ -750,6 +750,7 @@ public class ExpenseTest {
 
     private void createBudgetPlan(User user) {
         // 예산이 없는 카테고리의 반환 여부 테스트를 위해 절반의 카테고리만 예산 설정
+        List<BudgetPlan> budgetPlans = new ArrayList<>(COUNT_CATEGORY);
         for (long categoryId = 1; categoryId <= COUNT_CATEGORY; categoryId++) {
             BudgetPlan budgetPlan = BudgetPlan.builder()
                     .user(user)
@@ -757,8 +758,9 @@ public class ExpenseTest {
                     .amount(LocalDate.now().lengthOfMonth() * 10000L)
                     .category(Category.builder().id(categoryId).build())
                     .build();
-            budgetPlanRepository.save(budgetPlan);
+            budgetPlans.add(budgetPlan);
         }
+        budgetPlanRepository.saveAllAndFlush(budgetPlans);
     }
 
     private void createExpensesFromToday(User user, int minusDay) {


### PR DESCRIPTION
## 작업 내용

`saveAll()` 메서드 호출 시 다수의 `INSERT` Query가 Batch 처리 되도록, Generation Type 을 `IDENTITY`에서 `SEQUENCE`로 변경하였습니다.

## 테스트

736ms -> 284ms 로 오차를 고려하여 약 400ms, 50% 이상 개선되었습니다.

![image](https://github.com/limvik/budget-management-service/assets/37972432/2b0400f1-0cd1-4c26-ba50-610d80d1a4db)
